### PR TITLE
read-fit-model: adjust output files for portability

### DIFF
--- a/tests/testthat/test-read-fit-model.R
+++ b/tests/testthat/test-read-fit-model.R
@@ -19,3 +19,16 @@ test_that("read_fit_model.bbi_stan_model works correctly", {
   expect_true(inherits(smp, STAN_SMP_DIAG_CLASS))
   expect_equal(dim(smp), STAN_SMP_DIAG_DIM)
 })
+
+test_that("read_fit_model adjusts output files to be in model directory", {
+  tdir <- withr::local_tempdir("bbr.bayes-read-model-test")
+  mdir <- file.path(tdir, STAN_MOD_ID)
+  fs::dir_copy(STAN_MOD1_PATH, mdir)
+  fs::file_copy(file.path(STAN_ABS_MODEL_DIR, paste0(STAN_MOD_ID, ".yaml")),
+                tdir)
+
+  files <- read_fit_model(mdir)$output_files()
+  expect_true(all(fs::path_has_parent(files, mdir)))
+  expect_identical(basename(files),
+                   basename(read_fit_model(STAN_MOD1)$output_files()))
+})


### PR DESCRIPTION
read_fit_model.bbi_stan_model() returns a cmdstanr R6 object that has
the output CSV files stored as _absolute_ paths.  So, if the leading
path to the current model directory is different from that of the
original run (e.g., different user or machine), doing anything that
depends on these paths (e.g., $summary() or $draws()) will fail.

On read, we can automatically re-root these absolute paths because we
know they should be within the specified model's directory.
Unfortunately, cmdstanr doesn't seem to have a public way to adjust
these paths.  So, at least for now, reach into the private guts of the
R6 object.  (The plan is to also open an issue upstream to ask about
adding a public method for adjusting these paths.)

Fixes #3.

---

```
ip-10-128-42-15:bbr.bayes$ Rscript -e 'devtools::test()'
ℹ Testing bbr.bayes
✔ | F W S  OK | Context
✔ |         6 | adding files to Stan models [0.1s]
✔ |         6 | building data objects for modeling [0.4s]
✔ |         6 | checking Stan model integrity
✔ |         7 | check-up-to-date [0.3s]
✔ |         8 | config-log [0.4s]
✔ |         4 | copy-model-from
✔ |         5 | get-path-from-object
✔ |        10 | model-diff [0.1s]
✔ |         4 | model-summary [0.1s]
✔ |        10 | new-model
✔ |         4 | print
✔ |         8 | reading fit model objects from disk [0.4s]
✔ |         3 | run-log
✔ |        15 | testing submitting Stan models [62.4s]

══ Results ═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 64.5 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 96 ]
```

As I was working on this, it occurred to me that other functionality that relies on any of the [other saved files](https://mc-stan.org/cmdstanr/reference/fit-method-save_output_files.html) can probably trigger the same kind of issue.  But the output CSV files might be the only ones that matter in practice (and are certainly the most important ones).  It probably makes sense to hold off on the other ones until we know they're an issue and/or see how the upstream interaction goes.