### PR TITLE
set_stanargs: check for unknown arguments

### DIFF
--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -83,19 +83,7 @@ submit_stan_model_cmdstanr <- function(.mod,
   stanargs[["init"]] <- import_stan_init(.mod, .standata = standata_list, .stanargs = stanargs)
   rm(standata_list) # once we've passed this to import_stan_init() we don't need it in memory
 
-  # check args against sample()
-  invalid_stanargs <- setdiff(
-    names(stanargs),
-    methods::formalArgs(stanmod$sample)
-  )
-  if (length(invalid_stanargs) > 0) {
-    stop(paste(
-      "Attempting to pass invalid stanargs.",
-      "  The following are not accepted by cmdstanr::sample():",
-      paste(invalid_stanargs, collapse = ", "),
-      sep = "\n"
-    ), call. = FALSE)
-  }
+  check_unknown_stanargs(stanargs)
 
   # launch model
   res <- do.call(

--- a/tests/testthat/test-stanargs.R
+++ b/tests/testthat/test-stanargs.R
@@ -31,6 +31,15 @@ test_that("set_stanargs catches init", {
   )
 })
 
+test_that("set_stanargs checks for unknown args", {
+  mod2 <- copy_model_from(STAN_MOD1, STAN_MOD_ID2, .overwrite = TRUE)
+  withr::defer(cleanup_model(mod2))
+
+  expect_error(
+    set_stanargs(mod2, list(youdontknowme = NULL)),
+    regexp = "not accepted"
+  )
+})
 
 test_that("get_stanargs returns expected list", {
   mod2 <- copy_model_from(STAN_MOD1, STAN_MOD_ID2, .overwrite =T)


### PR DESCRIPTION
submit_model() aborts if the specified sample arguments aren't parameters of CmdStanModel$sample().  As of 7709cebe, sample arguments are defined via set_stanargs() rather than passed through submit_model(), so this check no longer happens at the time the caller sets the arguments.

The main reason set_stanargs() doesn't do this check is that it doesn't have a CmdStanModel object at hand (unlike submit_model). However, it can get one cheaply by calling cmdstan_model() with `compile = FALSE`.

Use that approach to do the argument check in set_stanargs().  Note that the check also remains in submit_model().  This catches edits the user makes directly to `*-stanargs.R` and also guards against the scenario where set_stanargs() was called with a cmdstanr version that supports different arguments than the cmdstanr that is loaded when submit_model() is called.

Closes #22.

---

cc: @andreashandel