### PR TITLE
safe_call_sourced: fix embedding of function name in errors

### DIFF
--- a/R/safe-source.R
+++ b/R/safe-source.R
@@ -42,11 +42,12 @@ safe_source_function <- function(.file, .func_name) {
 #'   doesn't inherit this class.
 #' @keywords internal
 safe_call_sourced <- function(.func, .args, .file = NULL, .expected_class = NULL) {
+  fname <- as.character(substitute(.func))
   .res <- tryCatch(
     do.call(.func, .args),
     error = function(.e) {
       err_msg <- paste(
-        glue("Calling `{as.character(substitute(.func))}()` from {.file} FAILED with the following:"),
+        glue("Calling `{fname}()` from {.file} FAILED with the following:"),
         .e$message
       )
       stop(err_msg, call. = FALSE)
@@ -55,7 +56,7 @@ safe_call_sourced <- function(.func, .args, .file = NULL, .expected_class = NULL
 
   if (!is.null(.expected_class) && !inherits(.res, .expected_class)) {
     err_msg <- paste(
-      glue("The result of `{as.character(substitute(.func))}()` was expected to be {.expected_class} but got the following:"),
+      glue("The result of `{fname}()` was expected to be {.expected_class} but got the following:"),
       paste(class(.res), collapse = ", ")
     )
     stop(err_msg, call. = FALSE)

--- a/tests/testthat/test-build-data.R
+++ b/tests/testthat/test-build-data.R
@@ -33,7 +33,7 @@ test_that("build_data.bbi_stan_model errors with flawed -standata.R", {
   # fails because it can't find the relative path to the data from the temp dir
   expect_error(
     build_data(new_mod),
-    regexp = "Calling.+FAILED.+fxa.data.csv' does not exist"
+    regexp = "Calling `make_standata.+FAILED.+fxa.data.csv' does not exist"
   )
 
   # replace -standata.R with non-working code
@@ -44,6 +44,16 @@ test_that("build_data.bbi_stan_model errors with flawed -standata.R", {
   expect_error(
     build_data(new_mod),
     regexp = "Loading.+FAILED.+unexpected end of input"
+  )
+
+  # replace -standata.R with function that returns wrong type
+  writeLines(
+    "make_standata <- function(.dir) 3",
+    build_path_from_model(new_mod, STANDATA_R_SUFFIX)
+  )
+  expect_error(
+    build_data(new_mod),
+    regexp = "`make_standata\\(\\)` was expected to be list"
   )
 
   # replace -standata.R with dummy function


### PR DESCRIPTION
safe_call_sourced() tries to put the name of the function passed as .func into the error message (e.g., "make_standata").  However, substitute(), which uses the current environment by default, is called within an inner function, so the original function name isn't found:

    func <- function(x) {
      f <- function(e) message(deparse(substitute(x)))
      f()
    }

    arg <- "value"
    func(arg)
    #> x

Move the substitute() calls outside of the inner functions.  (Another option would be to leave the substitute() calls within the inner functions and pass the environment of the outer function to substitute().)