### PR TITLE
drone: minor cleanup and tweaks

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,9 @@ steps:
   - R -s -e 'devtools::install_deps(upgrade = "never")'
   - git clone -b 1.5.0.9001 --depth 1 --single-branch https://github.com/metrumresearchgroup/bbr.git /tmp/bbr
   - R -s -e 'devtools::install("/tmp/bbr")'
-  - R -s -e 'cmdstanr::install_cmdstan(cores = 2)'
+  - |
+    R -s -e 'cmdstanr::install_cmdstan(cores = 2)' >/tmp/cmdstanr-install-stdout ||
+      { cat /tmp/cmdstanr-install-stdout; exit 1; }
   - R -s -e 'devtools::check()'
   environment:
     NOT_CRAN: true


### PR DESCRIPTION
This series makes a few minor tweaks to `.drone.yml`.  The last two commits make the primary functional changes and are things that I actually care about:

 * run `devtools::check` with `error_on = "note"` so that we can catch things like the use of unknown functions through build errors rather than needing to manually click through and check each build

 * don't flood the output with ~150 lines of cmdstan compilation output because that makes it harder to find the main `R CMD check` output
