### PR TITLE
read_fit_model.character: pass '...' to underlying method call

### DIFF
--- a/R/read-fit-model.R
+++ b/R/read-fit-model.R
@@ -30,7 +30,7 @@ read_fit_model <- function(.mod, ...) {
 #' @export
 read_fit_model.character <- function(.mod, ...) {
   checkmate::assert_string(.mod)
-  read_fit_model(read_model(.mod))
+  read_fit_model(read_model(.mod), ...)
 }
 
 #' @describeIn read_fit_model Returns a \pkg{posterior} draws object.

--- a/tests/testthat/test-read-fit-model.R
+++ b/tests/testthat/test-read-fit-model.R
@@ -5,6 +5,12 @@ context("reading fit model objects from disk")
 test_that("nmbayes: read_fit_model.character() works correctly", {
   res <- read_fit_model(NMBAYES_MOD1_PATH)
   expect_s3_class(res, "draws")
+
+  res <- read_fit_model(NMBAYES_MOD1_PATH,
+                        format = "df",
+                        include_iph = FALSE)
+  expect_s3_class(res, "draws_df")
+  expect_false("MCMCOBJ_IPH[1,1]" %in% posterior::variables(res))
 })
 
 test_that("nmbayes: read_fit_model() works correctly", {


### PR DESCRIPTION
The second commit fixes an oversight from df36379: `read_fit_model.bbi_nmbayes_model()` takes additional arguments, so `read_fit_model.character()` needs to pass along `...`.  The first commit corrects the name of the test that the second commit extends with a regression test.
