### PR TITLE
check_stan_model: suppress 'incomplete final line' warning

### DIFF
--- a/tests/testthat/test-check-stan-model.R
+++ b/tests/testthat/test-check-stan-model.R
@@ -88,3 +88,10 @@ test_that("check_stan_model supports checking .stan syntax", {
                  "syntax", ignore.case = TRUE)
   expect_false(res)
 })
+
+test_that("check_stan_model hides readLines() warning from cmdstan_model", {
+  tdir <- local_test_dir()
+  mod <- copy_model_from(STAN_MOD1, file.path(tdir, "mod"))
+  cat(" ", file = get_model_path(mod), append = TRUE)
+  expect_no_warning(check_stan_model(mod))
+})


### PR DESCRIPTION
During the workshop, @frenchjl called `check_stan_model()` and saw this warning:

```R
# delete final newline in inst/model/stan/bern/bern.stan
> check_stan_model(read_model("inst/model/stan/bern"))
 Warning message:
 In readLines(stan_file) :
   incomplete final line found on '/data/home/kylem/src/github/metrumresearchgroup/bbr.bayes/inst/model/stan/bern/bern.stan'
```

That's triggered by a cmdstanr `readLines()` call, not a warning given by us or cmdstanr's `$check_syntax()`.  This PR hides it so that the user doesn't think it's something that `check_stan_model()` is saying needs to be fixed.