### PR TITLE
stan_summary_log: fix non-scalar variable selection

### DIFF
--- a/R/summary-log.R
+++ b/R/summary-log.R
@@ -174,7 +174,9 @@ extract_param_summaries <- function(fit, variables, summary_fns) {
     # $summary().
     vars <- NULL
   } else if (!is.null(variables)) {
-    vars <- intersect(variables, fit$metadata()[["variables"]])
+    vars <- intersect(
+      variables,
+      union(fit$metadata()[["variables"]], fit$metadata()[["stan_variables"]]))
     if (!length(vars)) {
       return(NULL)
     }

--- a/tests/testthat/test-summary-log.R
+++ b/tests/testthat/test-summary-log.R
@@ -90,3 +90,18 @@ test_that("stan_summary_log(): summary_fns=list() selects no variables", {
   checkmate::expect_integer(slog$num_divergent, all.missing = FALSE)
   expect_no_match(names(slog), "lp__")
 })
+
+test_that("stan_summary_log(): non-indexed name selects non-scalar values", {
+  fit <- read_fit_model(file.path("model", "stan", "bern-gq"))
+  bern_gq_vars <- paste0(fit$metadata()$variables, "_mean")
+
+  slog <- stan_summary_log(file.path("model", "stan"),
+                           summary_fns = "mean", variables = "y_rep")
+  expect_true(all(bern_gq_vars %in% names(slog)))
+
+  # Scalar can be pulled out with index.
+  slog <- stan_summary_log(file.path("model", "stan"),
+                           summary_fns = "mean", variables = "y_rep[1]")
+  expect_true("y_rep[1]_mean" %in% names(slog))
+  expect_false(any(setdiff(bern_gq_vars, "y_rep[1]_mean") %in% names(slog)))
+})


### PR DESCRIPTION
The second commit makes non-scalar selection for the `stan_summary_log` behave as intended (gh-63).  The first commit touches up the description of a nearby test.