### PR TITLE
safe-source: restrict evaluation environment

### DIFF
--- a/R/bbr-stan.R
+++ b/R/bbr-stan.R
@@ -62,6 +62,16 @@
 #'     submission or to compare the resulting data to previously saved data on
 #'     disk.
 #'
+#'   * Note that `make_standata` will be evaluated in the parent environment of
+#'     your global session, giving it access to all other environments on your
+#'     search path. This means that you don't _need_ to prefix function calls
+#'     with the package name (e.g., `here::here()`), but doing so is recommended
+#'     so that `make_standata` doesn't depend on your search path state. As an
+#'     exception, you may be comfortable leaving base packages unqualified
+#'     (e.g., `rnorm()` rather than `stats::rnorm()`) because users are unlikely
+#'     to remove `package:stats` from their search path or to attach a package
+#'     that overrides `rnorm()`.
+#'
 #' ## Other Files and Directories
 #'
 #' There will be several other things created in the model directory, as the
@@ -83,6 +93,9 @@
 #'
 #'   * Will be called internally by `bbr` and the result passed as the `init`
 #'     argument to `$sample()`.
+#'
+#'   * See the `make_standata` entry above for details on the evaluation
+#'     environment.
 #'
 #'   * Note that `$sample()` supports passing
 #'     _"A function that returns a single list..."_. If you intend to use this
@@ -167,6 +180,9 @@
 #'    `make_fitted_params`, that takes a single argument, the model object. The
 #'    function can return any value accepted for the `fitted_params` argument of
 #'    [$generate_quantities()][cmdstanr::model-method-generate-quantities].
+#'
+#'    See the `make_standata` entry above for details on the evaluation
+#'    environment.
 #'
 #' "stan_gq" models can be created fresh with `new_model(..., .model_type =
 #' "stan_gq")`. However, for the more common case where the "stan_gq" model is

--- a/R/safe-source.R
+++ b/R/safe-source.R
@@ -12,7 +12,11 @@ safe_source_function <- function(.file, .func_name) {
   checkmate::assert_string(.file)
   checkmate::assert_string(.func_name)
 
-  .env <- new.env()
+  # Use global environment's parent, as opposed to base environment, to increase
+  # isolation while not requiring the user to qualify names for packages on
+  # their search path (e.g., they can still use "rnorm" rather than
+  # "stats::rnorm").
+  .env <- new.env(parent = parent.env(globalenv()))
   tryCatch(
     source(.file, local = .env),
     error = function(.e) {

--- a/man/bbr_stan.Rd
+++ b/man/bbr_stan.Rd
@@ -63,6 +63,15 @@ used to find data files for loading, for example
 \item Can be called (by \code{\link[=build_data]{build_data()}}) to generate the data for model
 submission or to compare the resulting data to previously saved data on
 disk.
+\item Note that \code{make_standata} will be evaluated in the parent environment of
+your global session, giving it access to all other environments on your
+search path. This means that you don't \emph{need} to prefix function calls
+with the package name (e.g., \code{here::here()}), but doing so is recommended
+so that \code{make_standata} doesn't depend on your search path state. As an
+exception, you may be comfortable leaving base packages unqualified
+(e.g., \code{rnorm()} rather than \code{stats::rnorm()}) because users are unlikely
+to remove \code{package:stats} from their search path or to attach a package
+that overrides \code{rnorm()}.
 }
 }
 
@@ -85,6 +94,8 @@ argument of \verb{$sample()}. There are several options; see the
 argument of \code{make_init()}.
 \item Will be called internally by \code{bbr} and the result passed as the \code{init}
 argument to \verb{$sample()}.
+\item See the \code{make_standata} entry above for details on the evaluation
+environment.
 \item Note that \verb{$sample()} supports passing
 \emph{"A function that returns a single list..."}. If you intend to use this
 option, your \code{make_init()} function must return \emph{the function} described,
@@ -163,6 +174,9 @@ not have an \code{init} argument.
 \code{make_fitted_params}, that takes a single argument, the model object. The
 function can return any value accepted for the \code{fitted_params} argument of
 \link[cmdstanr:model-method-generate-quantities]{$generate_quantities()}.
+
+See the \code{make_standata} entry above for details on the evaluation
+environment.
 }
 
 "stan_gq" models can be created fresh with \code{new_model(..., .model_type = "stan_gq")}. However, for the more common case where the "stan_gq" model is

--- a/tests/testthat/test-safe-source.R
+++ b/tests/testthat/test-safe-source.R
@@ -1,0 +1,14 @@
+test_that("safe_source_function() doesn't see user workspace", {
+  gvar <- "x"
+  genv <- globalenv()
+  if (is.null(genv[[gvar]])) {
+    on.exit(rm(list = gvar, envir = genv))
+    genv[[gvar]] <- 1
+  }
+
+  tfile <- withr::local_tempfile(lines = paste("foo <- function()", gvar))
+  expect_error(
+    safe_source_function(tfile, "foo")(),
+    gvar
+  )
+})


### PR DESCRIPTION
To create the environment for source(), safe_source_function() calls new.env() with the default value for `parent`, leading to the parent of the environment being the execution environment of safe_source_function().  That means that the evaluated function (e.g., make_standata) has access to any bindings in namespace:bbr.bayes and its parents (most notably imports:bbr.bayes and the global environment).

The sourced file should not have access to bbr.bayes namespace. Walking up the chain, some options for a more appropriate environment are

 1) the global environment

 2) the parent of the global environment

 3) the environment for the first base package encountered (e.g.,
    package:stats)

 4) the base environment

*1* should be intuitive for the caller because it follows what they would see if they called make_standata() and friends directly in the session.  The downside is that the sourced code can access bindings from the global environment, opening up the possibility for bugs.

Using the base environment (*4*) would prevent this, but it'd also prevent the user from accessing the package environments on the search path, including the base packages.  They'd have to qualify all package references (e.g., "stats::rnorm").

*2* keeps everything except for the global environment on the search path.  That eliminates the most likely source of leaks, but the evaluation can still be influenced by non-standard things that the user has attached (most likely packages, but this could also be data frames or non-package environments).

*3* could work okay most of the time, forcing the caller to qualify names for anything other than base packages.  However, we can't assume the set of base packages is the same across users (it can be configured by the defaultPackages option and R_DEFAULT_PACKAGES) or that a base package comes upstream of non-base packages in the search path (e.g., it won't if a non-base package is loaded in .Rprofile).

Go with *2* as a simple compromise between *1* and *4* that should eliminate the most common source of leaked outside state.

Closes #25.

---

<details>
<summary>demo: accessing namespace:bbr.bayes</summary>

```r
library(bbr.bayes)

withr::with_tempdir({
  suppressMessages({
    m <- bbr::new_model("mod", .model_type = "stan")
    cat("make_standata <- function(.dir) list(x = get_stan_path_impl)\n",
        file = file.path("mod", "mod-standata.R"))
    res <- build_data(m)
  })
})

print(res)
#> $x
#> function (.bbi_object, .suffix, .check_exists = TRUE)
#> {
#>     .path <- build_path_from_model(.bbi_object, .suffix)
#>     if (isTRUE(.check_exists)) {
#>         if (fs::is_dir(.path)) {
#>             checkmate::assert_directory_exists(.path)
#>         }
#>         else {
#>             checkmate::assert_file_exists(.path)
#>         }
#>     }
#>     return(.path)
#> }
#> <bytecode: 0x7ff4152fc3b0>
#> <environment: namespace:bbr.bayes>
```

output after pr:

```
Error: Calling `make_standata()` from /private/var/folders/5j/616gskv5451g0ytp_h0zzb5m0000gq/T/RtmpGuhXW6/file7cdc7e629d9e/mod/mod-standata.R FAILED with the following: object 'get_stan_path_impl' not found
Execution halted
```

</details>

<details>
<summary>demo: accessing safe_source_function execution environment</summary>

```r
library(bbr.bayes)

withr::with_tempdir({
  suppressMessages({
    m <- bbr::new_model("mod", .model_type = "stan")
    cat("make_standata <- function(.dir) list(x = .file, y = .func_name)\n",
        file = file.path("mod", "mod-standata.R"))
    res <- build_data(m)
  })
})

print(res)
#> $x
#> [1] "/private/var/folders/5j/616gskv5451g0ytp_h0zzb5m0000gq/T/RtmpytDBYF/file165ec54db1aab/mod/mod-standata.R"
#>
#> $y
#> [1] "make_standata"
#>
```

output after pr:

```
Error: Calling `make_standata()` from /private/var/folders/5j/616gskv5451g0ytp_h0zzb5m0000gq/T/Rtmp3gR7es/file7db71667ff7b/mod/mod-standata.R FAILED with the following: object '.file' not found
Execution halted
```
</details>