### PR TITLE
stanargs: don't write bbr_stanargs class to disk

### DIFF
--- a/R/stanargs.R
+++ b/R/stanargs.R
@@ -41,7 +41,7 @@ set_stanargs_impl <- function(method, .mod, .stanargs, .clear) {
   .args <- if (isTRUE(.clear)) {
     list()
   } else {
-    get_stanargs(.mod)
+    unclass(get_stanargs(.mod))
   }
 
   # check passed args

--- a/tests/testthat/test-stanargs.R
+++ b/tests/testthat/test-stanargs.R
@@ -47,6 +47,13 @@ test_that("set_stanargs checks for unknown args", {
   }
 })
 
+test_that("set_stanargs does not write custom class", {
+  mod <- new_model(local_test_dir(), .model_type = "stan")
+  set_stanargs(mod, list(seed = 39))
+  res <- dget(build_path_from_model(mod, STANARGS_SUFFIX))
+  expect_identical(class(res), "list")
+})
+
 test_that("get_stanargs returns expected list", {
   for (mod in list(STAN_MOD1, STAN_GQ_MOD)) {
     tdir <- local_test_dir()


### PR DESCRIPTION
get_stanargs() wraps the list in a custom child class so that it can define a tailored print() method.  That's just for rendering purposes, and the -stanargs.R file should contain a plain list.  And in most cases, bbr_stanargs class does not leak out to disk because 1) the arguments are sorted if there's more than one, and that drops the class and 2) if .clear=TRUE, the get_stanargs() result isn't used as the starting point.

Call unclass() on the get_stanargs() result to fix the remaining case: when .clear=FALSE and the length of the arguments is 1.

---

Once this lands in `main`, I'll merge it into gh-81.