### PR TITLE
updates for bbr 1.7.0 now being on MPN

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,8 +39,6 @@ steps:
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:cmdstanr
   commands:
   - R -s -e 'devtools::install_deps(upgrade = "never")'
-  - git clone -b 1.7.0 --depth 1 --single-branch https://github.com/metrumresearchgroup/bbr.git /tmp/bbr
-  - R -s -e 'devtools::install("/tmp/bbr")'
   - R -s -e 'devtools::check()'
   environment:
     NOT_CRAN: true
@@ -98,8 +96,6 @@ steps:
   - git config --global user.name Drony
   - git fetch --tags
   - R -s -e 'devtools::install_deps(upgrade = '"'"'never'"'"')'
-  - git clone -b 1.7.0 --depth 1 --single-branch https://github.com/metrumresearchgroup/bbr.git /tmp/bbr
-  - R -s -e 'devtools::install("/tmp/bbr")'
   - R -s -e 'pkgpub::create_tagged_repo(.dir = '"'"'/ephemeral'"'"')'
   environment:
     NOT_CRAN: true

--- a/README.md
+++ b/README.md
@@ -17,8 +17,15 @@ on CRAN.  They can be installed from GitHub with, e.g.,
 > remotes::install_git("git@github.com:metrumresearchgroup/bbr.bayes.git")
 ```
 
-`cmdstanr` is also available from the CRAN-like repositories at
-<https://mc-stan.org/r-packages/> and [MPN].
+The `bbr` and `cmdstanr` dependencies are also available from
+CRAN-like repositories:
+
+ * `bbr` is available on [MPN].  Use snapshot 2023-05-14 or later to
+   get the minimum version required by `bbr.bayes`.
+
+ * `cmdstanr` is available from [MPN] and
+   <https://mc-stan.org/r-packages/>.
+
 
 ## Documentation
 

--- a/pkgr.yml
+++ b/pkgr.yml
@@ -8,7 +8,7 @@ Packages:
 
 Repos:
   - CRAN: https://cran.rstudio.com
-  - MPN: https://mpn.metworx.com/snapshots/stable/2022-06-15 # cmdstanr
+  - MPN: https://mpn.metworx.com/snapshots/stable/2023-05-14 # bbr and cmdstanr
 
 Lockfile:
   Type: renv


### PR DESCRIPTION
Update various spots to account for bbr 1.7.0 (the minimum requirement for bbr.bayes) now being on MPN (as of 2023-05-14 snapshot).

---

I'm marking this as a draft until https://github-drone.metrumrg.com/ is operational again (hook is broken due to stale SSL certs).

