### PR TITLE
DESCRIPTION: require jsonlite 1.8.5 or later

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,6 +38,8 @@ steps:
   pull: never
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:cmdstanr
   commands:
+  - git clone -b 0.1.0 --depth 1 --single-branch https://github.com/metrumresearchgroup/nmrec.git /tmp/nmrec
+  - R -s -e 'devtools::install("/tmp/nmrec", upgrade = "never")'
   - R -s -e 'devtools::install_deps(upgrade = "never")'
   - R -s -e 'devtools::check()'
   environment:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     ellipsis,
     fs,
     glue,
-    jsonlite,
+    jsonlite (>= 1.8.5),
     magrittr,
     methods,
     posterior,


### PR DESCRIPTION
build_data() calls cmdstanr::write_stan_json(), which requests jsonlite write numbers with max precision.  jsonlite 1.8.5 changed the number of significant digits that it prints in this case.

That version of jsonlite is now on the latest MPN, so declare it as the minimum version to reduce cases where a difference in the jsonlite version is the reason for different results.

This is a follow-up to 4ea3f82 (tests: skip fxa-related tests that require latest jsonlite, 2023-06-09).

Closes #88.