### PR TITLE
Prepare for 0.1.1 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr.bayes
 Title: Bayesian modeling with BBR
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     c(person(given = "Seth",
              family = "Green",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# bbr.bayes 0.1.1
+
+## Changes
+
+`submit_model` no longer sets up a `.gitignore` rule for posterior
+CSVs of Stan models.  (#92)
+
+
 # bbr.bayes 0.1.0
 
 This initial release adds support for working with Stan models. (#81)


### PR DESCRIPTION
This is a small release to get out the Stan-related changes from gh-92 without waiting for the nmbayes-related work that's landing in `main` to be ready for release.

There are a few other changes, but none of them are user-facing code changes.

changeset: https://github.com/metrumresearchgroup/bbr.bayes/compare/0.1.0...release/0.1.1
