### PR TITLE
DESCRIPTION: drop unused 'digest' import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,6 @@ Imports:
     cmdstanr,
     data.table,
     diffobj,
-    digest,
     dplyr (>= 1.0.0),
     ellipsis,
     fs,


### PR DESCRIPTION
Clean up note flagged by scorecard:

```
* checking dependencies in R code ... NOTE
Namespace in Imports field not imported from: ‘digest’
  All declared Imports should be used.
```

(See commit message for why this went unnoticed.)