### PR TITLE
Updates for MPN additions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,9 +38,7 @@ steps:
   pull: never
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:cmdstanr
   commands:
-  - git clone -b 0.1.0 --depth 1 --single-branch https://github.com/metrumresearchgroup/nmrec.git /tmp/nmrec
-  - R -s -e 'devtools::install("/tmp/nmrec", upgrade = "never")'
-  - R -s -e 'devtools::install_deps(upgrade = "never")'
+  - R -s -e 'devtools::install_dev_deps(upgrade = "never")'
   - R -s -e 'devtools::check()'
   environment:
     NOT_CRAN: true
@@ -97,8 +95,8 @@ steps:
   - git config --global user.email drone@metrumrg.com
   - git config --global user.name Drony
   - git fetch --tags
-  - R -s -e 'devtools::install_deps(upgrade = '"'"'never'"'"')'
-  - R -s -e 'pkgpub::create_tagged_repo(.dir = '"'"'/ephemeral'"'"')'
+  - R -s -e 'devtools::install_dev_deps(upgrade = "never")'
+  - R -s -e 'pkgpub::create_tagged_repo(.dir = "/ephemeral")'
   environment:
     NOT_CRAN: true
   volumes:

--- a/README.md
+++ b/README.md
@@ -7,23 +7,25 @@ Bayes models.
 
 ## Installation
 
-`bbr.bayes` and two of its dependencies, `bbr` and `cmdstanr`, are not
-on CRAN.  They can be installed from GitHub with, e.g.,
-[remotes::install_git()][rig].
+You can install the latest release of `bbr.bayes` from [MPN].
+
+To install the latest development version from GitHub, you can use
+`remotes`:
 
 ```R
-> remotes::install_git("git@github.com:stan-dev/cmdstanr.git")
-> remotes::install_git("git@github.com:metrumresearchgroup/bbr.git")
-> remotes::install_git("git@github.com:metrumresearchgroup/bbr.bayes.git")
+# install.packages("remotes")
+remotes::install_github("metrumresearchgroup/bbr.bayes")
 ```
 
-The `bbr` and `cmdstanr` dependencies are also available from
-CRAN-like repositories:
+Note that a few `bbr.bayes` dependencies are not on CRAN but are
+available from other CRAN-like repos:
 
- * `bbr` is available on [MPN].  Use snapshot 2023-05-14 or later to
+ * [bbr] is available on [MPN].  Use snapshot 2023-05-14 or later to
    get the minimum version required by `bbr.bayes`.
 
- * `cmdstanr` is available from [MPN] and
+ * [nmrec] is available on [MPN] as of the 2023-09-19 snapshot.
+
+ * [cmdstanr] is available from [MPN] and
    <https://mc-stan.org/r-packages/>.
 
 
@@ -52,7 +54,7 @@ to provide isolation. To set up an environment with pkgr and renv:
 [cmdstanr]: https://mc-stan.org/cmdstanr/
 [gss]: https://metrumresearchgroup.github.io/bbr.bayes/articles/getting-started-stan.html
 [MPN]: https://mpn.metworx.com/docs/snapshots
+[nmrec]: https://metrumresearchgroup.github.io/nmrec
 [pkgr]: https://github.com/metrumresearchgroup/pkgr
 [renv]: https://rstudio.github.io/renv/
-[rig]: https://remotes.r-lib.org/reference/install_git.html
 [Stan]: https://mc-stan.org/

--- a/pkgr.yml
+++ b/pkgr.yml
@@ -8,8 +8,7 @@ Packages:
 
 Repos:
   - CRAN: https://cran.rstudio.com
-  - MPN: https://mpn.metworx.com/snapshots/stable/2023-05-14 # bbr and cmdstanr
-  - nmrec: https://s3.amazonaws.com/mpn.metworx.dev/releases/nmrec/0.1.0
+  - MPN: https://mpn.metworx.com/snapshots/stable/2023-10-19 # bbr, cmdstanr, nmrec
 
 Lockfile:
   Type: renv


### PR DESCRIPTION
This series updates various bits now that bbr.bayes and nmrec are on MPN.  Variants of the drone and pkgr.yml changes are present in #75, but 1) it's not good for these to be held up by that PR and 2) the plan is to replace that PR with a fresh series.