### PR TITLE
test-shrinkage: use local_test_dir helper

### DIFF
--- a/tests/testthat/test-shrinkage.R
+++ b/tests/testthat/test-shrinkage.R
@@ -142,7 +142,7 @@ test_that("shrinkage(): rank matches for use_sd=TRUE and use_sd=FALSE", {
 })
 
 test_that("shrinkage.bbi_nmbayes_model() falls back to *.shk files", {
-  tdir <- withr::local_tempdir("bbr-bayes-")
+  tdir <- local_test_dir()
   modfile <- get_model_path(NMBAYES_MOD1)
   fs::file_copy(modfile, tdir)
   fs::file_copy(get_yaml_path(NMBAYES_MOD1), tdir)


### PR DESCRIPTION
Use local_test_dir() so that the temporary directory path is normalized, avoiding the issues described at 13c2053 (tests: add local_tempdir() wrapper that returns normalized paths, 2023-01-16).

---

This is a small fix that was included in gh-75.  I'm extracting it to a dedicated PR because it's not directly related to those changes and there's no reason for it to be held up by that PR.  And the plan is to replace gh-75 with a rerolled series, so now is a good time to do it.