### PR TITLE
nmbayes: don't rely on fread header detection

### DIFF
--- a/R/nmbayes-helpers.R
+++ b/R/nmbayes-helpers.R
@@ -75,24 +75,25 @@ get_chain_files <- function(.mod, extension, chain_dirs = NULL,
   return(files)
 }
 
-fread_chain_file <- function(file, select = NULL) {
+fread_chain_file <- function(file, select = NULL, skip = 1) {
   tibble::as_tibble(
     data.table::fread(file = file,
                       na.strings = ".",
                       data.table = FALSE,
                       verbose = FALSE,
-                      select = select))
+                      select = select,
+                      skip = skip))
 }
 
 #' Peek at beginning of file to determine column names.
 #'
-#' @param file,nrows Passed to `data.table::fread()`. Note that `nrows` must be
-#'   above the number of lines that `fread` automatically skips before getting
-#'   to the header.
+#' @param file,skip Passed to `data.table::fread()`. Only a single row is read,
+#'   so `skip` must point `fread()` to the header line.
 #' @noRd
-fread_peek_at_columns <- function(file, nrows = 5) {
+fread_peek_at_columns <- function(file, skip = 1) {
   colnames(data.table::fread(file = file,
-                             nrows = nrows,
+                             skip = skip,
+                             nrows = 1,
                              verbose = FALSE))
 }
 

--- a/R/shrinkage.R
+++ b/R/shrinkage.R
@@ -78,9 +78,14 @@ shrinkage.bbi_nmbayes_model <- function(errors, ..., use_sd = TRUE) {
       stop("No *.iph or *.shk files found; cannot calculate shrinkage")
     }
 
-    shk <- purrr::map_dfr(shk_files, fread_chain_file, .id = "chain") %>%
-      # From Intro to NM 7: "Type 4=%Eta shrinkage SD version"
-      dplyr::filter(.data$TYPE == 4)
+    shk <- purrr::map_dfr(shk_files, fread_chain_file, .id = "chain")
+    if (!"TYPE" %in% names(shk)) {
+      stop("Failed to extract TYPE column from *.shk files:\n",
+           paste("  -", shk_files, collapse = "\n"))
+    }
+
+    # From Intro to NM 7: "Type 4=%Eta shrinkage SD version"
+    shk <- dplyr::filter(shk, .data$TYPE == 4)
 
     if (!nrow(shk)) {
       stop("Failed to extract TYPE=4 rows from *.shk files:\n",

--- a/tests/testthat/test-shrinkage.R
+++ b/tests/testthat/test-shrinkage.R
@@ -175,9 +175,11 @@ test_that("shrinkage.bbi_nmbayes_model() falls back to *.shk files", {
 
   shk_files <- fs::path_ext_set(iphs, "shk")
 
-  invalid_data <- tibble::tibble(TYPE = 1:2)
+  # No TYPE=4 row
   for (f in shk_files) {
-    readr::write_csv(invalid_data, f)
+    # Drop TYPE=4 value.
+    lines <- sub(" 4 ", " 1 ", readLines(f))
+    writeLines(lines, f)
   }
   expect_error(shrinkage(mod), "TYPE=4")
 

--- a/tests/testthat/test-shrinkage.R
+++ b/tests/testthat/test-shrinkage.R
@@ -183,6 +183,13 @@ test_that("shrinkage.bbi_nmbayes_model() falls back to *.shk files", {
   }
   expect_error(shrinkage(mod), "TYPE=4")
 
+  # No TYPE column found on second line
+  for (f in shk_files) {
+    lines <- readLines(f)
+    writeLines(lines[2:length(lines)], f)
+  }
+  expect_error(shrinkage(mod), "extract TYPE column")
+
   # No TYPE column
   for (f in shk_files) {
     readr::write_delim(tibble::tibble(foo = 1:2, bar = 3:4), f, delim = " ")

--- a/tests/testthat/test-shrinkage.R
+++ b/tests/testthat/test-shrinkage.R
@@ -183,6 +183,12 @@ test_that("shrinkage.bbi_nmbayes_model() falls back to *.shk files", {
   }
   expect_error(shrinkage(mod), "TYPE=4")
 
+  # No TYPE column
+  for (f in shk_files) {
+    readr::write_delim(tibble::tibble(foo = 1:2, bar = 3:4), f, delim = " ")
+  }
+  expect_error(shrinkage(mod), "extract TYPE column")
+
   fs::file_delete(shk_files)
   expect_error(shrinkage(mod), "cannot calculate")
 })


### PR DESCRIPTION
As described in the final commit here, we rely on fread's header detection.  A while ago @timwaterhouse noted that he's hit into issues with the auto-detection on NONMEM files, so it's best to explicitly specify skip.   We made those changes, but they were locked up in gh-75.  The fread changes are not tied to that PR, so this series extracts them to get them into the main line sooner.  (And now's a good time to do so because the plan is to replace gh-75 with a rerolled series.)

This change broke a shrinkage test case because it was relying on fread's auto-detection; the first two commits deal with that.