### PR TITLE
test-copy-model-from.R: adjust check for bbr change

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -62,6 +62,69 @@ trigger:
 ---
 kind: pipeline
 type: docker
+name: bbr-main
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: pull
+  image: omerxx/drone-ecr-auth
+  commands:
+  - $(aws ecr get-login --no-include-email --region us-east-1)
+  - docker pull 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:cmdstanr
+  volumes:
+  - name: docker.sock
+    path: /var/run/docker.sock
+
+- name: Install bbi
+  pull: never
+  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:cmdstanr
+  commands:
+    - |
+      curl -fSsL "$BBI_URL/$BBI_VERSION/bbi_linux_amd64.tar.gz" |
+        tar -z --extract --to-stdout >/ephemeral/bbi
+    - chmod +x /ephemeral/bbi
+    - /ephemeral/bbi version
+
+  environment:
+    BBI_VERSION: v3.2.2
+    BBI_URL: https://github.com/metrumresearchgroup/bbi/releases/download
+  volumes:
+  - name: cache
+    path: /ephemeral
+
+- name: "Check package: R 4.1"
+  pull: never
+  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:cmdstanr
+  commands:
+  - R -s -e 'devtools::install_dev_deps(upgrade = "never")'
+  - git clone --depth 1 --single-branch https://github.com/metrumresearchgroup/bbr.git /tmp/bbr
+  - R -s -e 'devtools::install("/tmp/bbr")'
+  - R -s -e 'devtools::check()'
+  environment:
+    NOT_CRAN: true
+    BBI_EXE_PATH: /ephemeral/bbi
+  volumes:
+  - name: cache
+    path: /ephemeral
+
+volumes:
+- name: docker.sock
+  host:
+    path: /var/run/docker.sock
+- name: cache
+  temp: {}
+
+trigger:
+  event:
+    exclude:
+    - promote
+
+---
+kind: pipeline
+type: docker
 name: bbr.bayes-release
 
 platform:

--- a/tests/testthat/test-copy-model-from.R
+++ b/tests/testthat/test-copy-model-from.R
@@ -96,7 +96,7 @@ test_that("copy_model_as_nmbayes(): .update_model_file=FALSE disables model upda
 test_that("copy_model_as_nmbayes() keeps trailing comments", {
   tdir <- local_test_dir()
   file_parent <- file.path(tdir, "1.ctl")
-  lines_parent <- c("$prob one",
+  lines_parent <- c("$PROB one",
                     "$EST METHOD=SAEM",
                     "  abort",
                     "; comment1",
@@ -109,7 +109,7 @@ test_that("copy_model_as_nmbayes() keeps trailing comments", {
   mod_lines <- readLines(get_model_path(mod))
   expect_identical(
     setdiff(lines_parent, mod_lines),
-    c("$EST METHOD=SAEM", "  abort", "$EST METHOD=ITS")
+    c("$PROB one", "$EST METHOD=SAEM", "  abort", "$EST METHOD=ITS")
   )
   expect_match(mod_lines, "nmbayes models require", all = FALSE)
 })


### PR DESCRIPTION
copy_model_as_nmbayes() calls bbr::copy_model_from() underneath. copy_model_from() is supposed to overwrite the $PROBLEM record for the copied model, but it only handled upper cases record names until bbr's 13fb8e5f (copy_control_stream: use nmrec instead of regex, 2023-07-21).

A copy_model_as_nmbayes() test checks for lines that it expects to be in the parent model but not the new one.  It uses "$prob" for the record name, and expects the old bbr behavior (i.e. the same problem line is in both the parent and child), leading to a failure with the unreleased bbr.

Use an upper case $PROB in the parent model so that copy_model_from() updates the record for bbr's versions before and after 13fb8e5f.

Re: https://github.com/metrumresearchgroup/bbr/pull/604

---

### Test matrix

**bbr.bayes main, bbr 1.7.0**

```
$ git rev-parse HEAD
2894a2f7e0d674f18d9e4ca39d9dd87025fbde1f
$ git -C ../bbr rev-parse HEAD
d12884cb7611dbd8ac21904fc0931f0ff707642e

$ Rscript -e 'devtools::test(filter = "copy-model-from")'
ℹ Testing bbr.bayes
✔ | F W  S  OK | Context
✔ |         52 | copy-model-from [1.1s]

══ Results ════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 1.1 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 52 ]
```

**bbr.bayes this PR, bbr 1.7.0**

```
$ git rev-parse HEAD
2323f5a196dc9109b9e7f19dac3d8cff1c199a77
$ git -C ../bbr rev-parse HEAD
d12884cb7611dbd8ac21904fc0931f0ff707642e

$ Rscript -e 'devtools::test(filter = "copy-model-from")'
ℹ Testing bbr.bayes
✔ | F W  S  OK | Context
✔ |         52 | copy-model-from [1.1s]

══ Results ════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 1.1 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 52 ]
```


**bbr.bayes main, bbr main**

```
$ git rev-parse HEAD
2894a2f7e0d674f18d9e4ca39d9dd87025fbde1f
$ git -C ../bbr rev-parse HEAD
e5546f08055e181728944d365f8543ca55d3ab6d

$ Rscript -e 'devtools::test(filter = "copy-model-from")'
ℹ Testing bbr.bayes
✔ | F W  S  OK | Context
✖ | 1       51 | copy-model-from [1.1s]
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Failure ('test-copy-model-from.R:110:3'): copy_model_as_nmbayes() keeps trailing comments
setdiff(lines_parent, mod_lines) not identical to c("$EST METHOD=SAEM", "  abort", "$EST METHOD=ITS").
Lengths differ: 4 is not 3
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

══ Results ════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 1.1 s

── Failed tests ───────────────────────────────────────────────────────────────────────────────────────────────────────
Failure ('test-copy-model-from.R:110:3'): copy_model_as_nmbayes() keeps trailing comments
setdiff(lines_parent, mod_lines) not identical to c("$EST METHOD=SAEM", "  abort", "$EST METHOD=ITS").
Lengths differ: 4 is not 3

[ FAIL 1 | WARN 0 | SKIP 0 | PASS 51 ]
```

**bbr.bayes PR, bbr main**

```
$ git rev-parse HEAD
2323f5a196dc9109b9e7f19dac3d8cff1c199a77
$ git -C ../bbr rev-parse HEAD
e5546f08055e181728944d365f8543ca55d3ab6d

$ Rscript -e 'devtools::test(filter = "copy-model-from")'
ℹ Testing bbr.bayes
✔ | F W  S  OK | Context
✔ |         52 | copy-model-from [1.1s]

══ Results ════════════════════════════════════════════════════════════════════════════════════════════════════════════
Duration: 1.1 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 52 ]
```
