### PR TITLE
Use etasrc argument to fix etas in sim_ipred

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Suggests:
     future,
     future.apply,
     knitr,
-    mrgsolve (>= 1.0.8),
+    mrgsolve (>= 1.2.0),
     nmrec,
     npde,
     progressr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,11 @@ Authors@R:
       person(given = "Jonathan",
              family = "French",
              role = "aut",
-             email = "jonathanf@metrumrg.com"))
+             email = "jonathanf@metrumrg.com"),
+      person(given = "Kyle T", family = "Baron",
+             role = "aut",
+             email = "kyleb@metrumrg.com",
+             comment = c(ORCID = "0000-0001-7252-5656")))
 Description: This package extends the BBR package for Bayesian modeling.
     The current focus is on supporting 'Stan' via the 'CmdStanR'
     interface.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr.bayes
 Title: Bayesian modeling with BBR
-Version: 0.1.1.8000
+Version: 0.1.1.8001
 Authors@R: 
     c(person(given = "Seth",
              family = "Green",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Suggests:
     future,
     future.apply,
     knitr,
-    mrgsolve,
+    mrgsolve (>= 1.0.8),
     nmrec,
     npde,
     progressr,

--- a/R/nm-join-bayes.R
+++ b/R/nm-join-bayes.R
@@ -447,7 +447,6 @@ sim_epred <- function(mod_mrgsolve, exts, data, join_col, y_col, pbar) {
 sim_ipred <- function(mod, mod_mrgsolve, exts, data, join_col, y_col, pbar) {
   # Note: Read these directly rather than using as_draws_df() to avoid
   # unnecessary reshaping. See ext note above.
-  data <- data[grep("^ETA?[0-9]+$", colnames(data), invert = TRUE)]
   iph_files <- chain_paths_impl(mod,
     extension = "iph",
     check_exists = "all_or_none"
@@ -471,6 +470,9 @@ sim_ipred <- function(mod, mod_mrgsolve, exts, data, join_col, y_col, pbar) {
   })
   rm(ipar_full)
 
+  # Purge post-hoc ETAs just in case there is logic written into mrgsolve model
+  # (see gh-117).
+  data <- data[grep("^ETA?[0-9]+$", colnames(data), invert = TRUE)]
   mod_sim <- mrgsolve::zero_re(mod_mrgsolve, "omega") %>%
     mrgsolve::data_set(data)
 

--- a/R/nm-join-bayes.R
+++ b/R/nm-join-bayes.R
@@ -481,7 +481,7 @@ sim_ipred <- function(mod, mod_mrgsolve, exts, data, join_col, y_col, pbar) {
         mrgsolve::idata_set(mod_sim, ipar_n) %>%
           mrgsolve::smat(mrgsolve::as_bmat(ext_row, "SIGMA")) %>%
           mrgsolve::mrgsim_df(
-            obsonly = TRUE, carry_out = join_col, etasrc = "data.all"
+            obsonly = TRUE, carry_out = join_col, etasrc = "idata.all"
           ) %>%
           dplyr::select(all_of(join_col), DV_sim = all_of(y_col)) %>%
           dplyr::mutate(sample = n)

--- a/R/nm-join-bayes.R
+++ b/R/nm-join-bayes.R
@@ -480,7 +480,9 @@ sim_ipred <- function(mod, mod_mrgsolve, exts, data, join_col, y_col, pbar) {
         ipar_n <- dplyr::filter(ipar, .data$draw == ext_row$draw)
         mrgsolve::idata_set(mod_sim, ipar_n) %>%
           mrgsolve::smat(mrgsolve::as_bmat(ext_row, "SIGMA")) %>%
-          mrgsolve::mrgsim_df(obsonly = TRUE, carry_out = join_col) %>%
+          mrgsolve::mrgsim_df(
+            obsonly = TRUE, carry_out = join_col, etasrc = "data.all"
+          ) %>%
           dplyr::select(all_of(join_col), DV_sim = all_of(y_col)) %>%
           dplyr::mutate(sample = n)
       })

--- a/R/nm-join-bayes.R
+++ b/R/nm-join-bayes.R
@@ -473,8 +473,7 @@ sim_ipred <- function(mod, mod_mrgsolve, exts, data, join_col, y_col, pbar) {
   # Purge post-hoc ETAs just in case there is logic written into mrgsolve model
   # (see gh-117).
   data <- data[grep("^ETA?[0-9]+$", colnames(data), invert = TRUE)]
-  mod_sim <- mrgsolve::zero_re(mod_mrgsolve, "omega") %>%
-    mrgsolve::data_set(data)
+  mod_sim <- mrgsolve::data_set(mod_mrgsolve, data)
 
   res <- future.apply::future_Map(
     function(ext, ipar) {

--- a/R/nm-join-bayes.R
+++ b/R/nm-join-bayes.R
@@ -445,6 +445,7 @@ sim_epred <- function(mod_mrgsolve, exts, data, join_col, y_col, pbar) {
 sim_ipred <- function(mod, mod_mrgsolve, exts, data, join_col, y_col, pbar) {
   # Note: Read these directly rather than using as_draws_df() to avoid
   # unnecessary reshaping. See ext note above.
+  data <- data[grep("^ETA?[0-9]+$", colnames(data), invert = TRUE)]
   iph_files <- chain_paths_impl(mod,
     extension = "iph",
     check_exists = "all_or_none"

--- a/R/nm-join-bayes.R
+++ b/R/nm-join-bayes.R
@@ -473,7 +473,6 @@ sim_ipred <- function(mod, mod_mrgsolve, exts, data, join_col, y_col, pbar) {
   # Purge post-hoc ETAs just in case there is logic written into mrgsolve model
   # (see gh-117).
   data <- data[grep("^ETA?[0-9]+$", colnames(data), invert = TRUE)]
-  mod_sim <- mrgsolve::data_set(mod_mrgsolve, data)
 
   res <- future.apply::future_Map(
     function(ext, ipar) {
@@ -482,11 +481,13 @@ sim_ipred <- function(mod, mod_mrgsolve, exts, data, join_col, y_col, pbar) {
         pbar("IPRED")
         ext_row <- ext[n, ]
         ipar_n <- dplyr::filter(ipar, .data$draw == ext_row$draw)
-        mrgsolve::idata_set(mod_sim, ipar_n) %>%
-          mrgsolve::smat(mrgsolve::as_bmat(ext_row, "SIGMA")) %>%
-          mrgsolve::mrgsim_df(
-            obsonly = TRUE, carry_out = join_col, etasrc = "idata.all"
-          ) %>%
+        mrgsolve::mrgsim_df(
+          mod_mrgsolve,
+          data = data, idata = ipar_n,
+          sigma = mrgsolve::as_bmat(ext_row, "SIGMA"),
+          obsonly = TRUE, carry_out = join_col,
+          etasrc = "idata.all"
+        ) %>%
           dplyr::select(all_of(join_col), DV_sim = all_of(y_col)) %>%
           dplyr::mutate(sample = n)
       })

--- a/inst/model/mrgsolve/1100.mod
+++ b/inst/model/mrgsolve/1100.mod
@@ -8,11 +8,6 @@ WT   = 70
 EGFR = 90
 AGE  = 35
 ALB  = 4.5
-ETA1 = 0
-ETA2 = 0
-ETA3 = 0
-ETA4 = 0
-ETA5 = 0
 
 [ nmext ]
 run = "1100-1"
@@ -29,11 +24,11 @@ double CLWT   = log(WT/70) * 0.75;
 double V3WT   = log(WT/70);
 double QWT    = log(WT/70) * 0.75;
 
-capture KA = exp(THETA1 + ETA1 + ETA(1));
-capture V2 = exp(THETA2 + V2WT + ETA2 + ETA(2));
-capture CL = exp(THETA3 + CLWT + CLEGFR + CLAGE + CLALB + ETA3 + ETA(3));
-capture V3 = exp(THETA4 + V3WT + ETA4 + ETA(4));
-capture Q  = exp(THETA5 + QWT + ETA5 + ETA(5));
+capture KA = exp(THETA1 + ETA(1));
+capture V2 = exp(THETA2 + V2WT + ETA(2));
+capture CL = exp(THETA3 + CLWT + CLEGFR + CLAGE + CLALB + ETA(3));
+capture V3 = exp(THETA4 + V3WT + ETA(4));
+capture Q  = exp(THETA5 + QWT + ETA(5));
 
 double S2 = V2/1000; //; dose in mcg, conc in mcg/mL
 


### PR DESCRIPTION
For discussion: 

- We need mrgsolve 1.0.8 or greater
- Passing `etasrc = "data.all"` will tell mrgsolve to get ETAs from the data set; it will generate an error if it doesn't find all of them
- Drop `ETAn` parameters from the example model

Considerations:

- I'm not sure what else might need to change / update. 
- Still testing this ... I think we can compare output from the previous configuration and make sure it is identical to the update?
- Should we wrap the `mrgsim_df()` call in `sim_pred()` in `tryCatch()` in case it errors?