### PR TITLE
Drop post-hoc etas from data set

### DIFF
--- a/R/nm-join-bayes.R
+++ b/R/nm-join-bayes.R
@@ -470,6 +470,8 @@ sim_ipred <- function(mod, mod_mrgsolve, exts, data, join_col, y_col, pbar) {
   })
   rm(ipar_full)
 
+  # Drop post-hoc ETAs so that ETAs are randomly generated within model.
+  data <- data[grep("^ETA?[0-9]+$", colnames(data), invert = TRUE)]
   mod_sim <- mrgsolve::zero_re(mod_mrgsolve, "omega") %>%
     mrgsolve::data_set(data)
 


### PR DESCRIPTION
# Summary

This PR purges ETAs from the `data` set prior to simulating in `sim_ipred()`; a similar step was taken in `sim_epred()`. 

@kyleam I'd like to merge this into `main` to get it in place. I wonder if this is confusing some of the investigation around the `etasrc` discrepancy.

Possible that we eventually want to do this earlier on in the function. 