### PR TITLE
stan submit_model: add .bbi_args for generic/method consistency

### DIFF
--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -102,6 +102,8 @@ submit_model.bbi_nmbayes_model <- function(
 #'
 #' @name stan_submit_model
 #' @inheritParams bbr::submit_model
+#' @param .bbi_args Unused argument (present for compatibility with
+#'   [bbr::submit_model()]).
 #' @param .mode Mode of model submission. Stan models currently only support
 #'   local execution.
 #' @param ... Additional arguments (ignored for all Stan models).
@@ -113,11 +115,15 @@ NULL
 #' @export
 submit_model.bbi_stan_model <- function(
   .mod,
+  .bbi_args = NULL,
   .mode = c("local"),
   ...,
   .overwrite = NULL
 ) {
   rlang::check_dots_empty()
+  if (!is.null(.bbi_args)) {
+    stop(".bbi_args must be NULL for model_type=stan")
+  }
   res <- submit_stan_model_cmdstanr(
     .mod,
     "sample",
@@ -129,9 +135,12 @@ submit_model.bbi_stan_model <- function(
 
 #' @rdname stan_submit_model
 #' @export
-submit_model.bbi_stan_gq_model <- function(.mod, .mode = c("local"),
+submit_model.bbi_stan_gq_model <- function(.mod, .bbi_args = NULL, .mode = c("local"),
                                            ..., .overwrite = NULL) {
   rlang::check_dots_empty()
+  if (!is.null(.bbi_args)) {
+    stop(".bbi_args must be NULL for model_type=stan_gq")
+  }
 
   # Note: get_stan_gq_parent() will abort if any gq_parent lacks a YAML.
   gq_parent <- get_stan_gq_parent(.mod)

--- a/man/stan_submit_model.Rd
+++ b/man/stan_submit_model.Rd
@@ -6,12 +6,27 @@
 \alias{submit_model.bbi_stan_gq_model}
 \title{Submit model based on a \code{bbi_stan_model} object}
 \usage{
-\method{submit_model}{bbi_stan_model}(.mod, .mode = c("local"), ..., .overwrite = NULL)
+\method{submit_model}{bbi_stan_model}(
+  .mod,
+  .bbi_args = NULL,
+  .mode = c("local"),
+  ...,
+  .overwrite = NULL
+)
 
-\method{submit_model}{bbi_stan_gq_model}(.mod, .mode = c("local"), ..., .overwrite = NULL)
+\method{submit_model}{bbi_stan_gq_model}(
+  .mod,
+  .bbi_args = NULL,
+  .mode = c("local"),
+  ...,
+  .overwrite = NULL
+)
 }
 \arguments{
 \item{.mod}{The model object to submit.}
+
+\item{.bbi_args}{Unused argument (present for compatibility with
+\code{\link[bbr:submit_model]{bbr::submit_model()}}).}
 
 \item{.mode}{Mode of model submission. Stan models currently only support
 local execution.}

--- a/tests/testthat/test-submit-model.R
+++ b/tests/testthat/test-submit-model.R
@@ -1,0 +1,5 @@
+test_that("stan: submit_model aborts if .bbi_args is passed", {
+  for (m in list(STAN_MOD1, STAN_GQ_MOD)) {
+    expect_error(submit_model(m, .bbi_args = "foo"), ".bbi_args", fixed = TRUE)
+  }
+})


### PR DESCRIPTION
In a8e18fa (submit_model.bbi_stan_model: drop unsupported args, 2023-01-16), I dropped .bbi_args from the submit_model() method for Stan models.  Under newer versions of R, the check rightly flags this:

    checking S3 generic/method consistency ... WARNING
    [...]
    submit_model:
      function(.mod, .bbi_args, .mode, ..., .overwrite, .config_path,
               .wait, .dry_run)
    submit_model.bbi_stan_model:
      function(.mod, .mode, ..., .overwrite)

Add back .bbi_args so that the meaning of the second positional argument is consistent between the generic and Stan submit_model() methods.

Note that this _could_ break some existing callers that pass `.mode` as a positional argument, but it's very unlikely that anyone is doing that given 1) the early stage of this package and 2) that Stan models do not currently support any other .mode value than the "local" default.