### PR TITLE
Prepare 0.2.0 release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -152,6 +152,9 @@ steps:
   - git config --global user.name Drony
   - git fetch --tags
   - R -s -e 'devtools::install_dev_deps(upgrade = "never")'
+  # TODO: Use bbr from MPN once >= 1.9.0 is available.
+  - git clone --depth 1 https://github.com/metrumresearchgroup/bbr.git /tmp/bbr
+  - R -s -e 'devtools::install("/tmp/bbr")'
   - R -s -e 'pkgpub::create_tagged_repo(.dir = "/ephemeral")'
   environment:
     NOT_CRAN: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -144,6 +144,23 @@ steps:
   - name: docker.sock
     path: /var/run/docker.sock
 
+- name: Install bbi
+  pull: never
+  image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:cmdstanr
+  commands:
+    - |
+      curl -fSsL "$BBI_URL/$BBI_VERSION/bbi_linux_amd64.tar.gz" |
+        tar -z --extract --to-stdout >/ephemeral/bbi
+    - chmod +x /ephemeral/bbi
+    - /ephemeral/bbi version
+
+  environment:
+    BBI_VERSION: v3.3.0
+    BBI_URL: https://github.com/metrumresearchgroup/bbi/releases/download
+  volumes:
+  - name: cache
+    path: /ephemeral
+
 - name: Build package
   pull: never
   image: 906087756158.dkr.ecr.us-east-1.amazonaws.com/r-dev-ci-mpn-4.1:cmdstanr
@@ -158,6 +175,7 @@ steps:
   - R -s -e 'pkgpub::create_tagged_repo(.dir = "/ephemeral")'
   environment:
     NOT_CRAN: true
+    BBI_EXE_PATH: /ephemeral/bbi
   volumes:
   - name: cache
     path: /ephemeral

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,8 @@ Authors@R:
              email = "kyleb@metrumrg.com",
              comment = c(ORCID = "0000-0001-7252-5656")))
 Description: This package extends the BBR package for Bayesian modeling.
-    The current focus is on supporting 'Stan' via the 'CmdStanR'
-    interface.
+    It adds supports for running 'Stan' models via the 'CmdStanR' interface and
+    for running NONMEM models with Bayesian estimation methods via 'bbi'.
 License: MIT + file LICENSE
 URL: https://metrumresearchgroup.github.io/bbr.bayes, https://github.com/metrumresearchgroup/bbr.bayes
 BugReports: https://github.com/metrumresearchgroup/bbr.bayes/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ BugReports: https://github.com/metrumresearchgroup/bbr.bayes/issues
 Depends:
     R (>= 3.5)
 Imports: 
-    bbr (>= 1.7.0),
+    bbr (>= 1.10.0),
     checkmate,
     cli,
     cmdstanr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr.bayes
 Title: Bayesian modeling with BBR
-Version: 0.1.1.8002
+Version: 0.2.0
 Authors@R: 
     c(person(given = "Seth",
              family = "Green",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,44 @@
+# bbr.bayes 0.2.0
+
+## New features and changes
+
+* `bbr.bayes` now requires `bbr` 1.10.0 or later.  (#134)
+
+### NONMEM Bayes
+
+* Initial support has been added for NONMEM Bayes models via the
+  `bbi_nmbayes_model` model type.  **Compatibility note:** the 0.1.0
+  release included a `bbi_nmbayes_model` model type that was marked as
+  experimental and is not compatible with the new design.  (#84, #108,
+  #133)
+
+* New `copy_model_as_nmbayes()` function for creating a
+  `bbi_nmbayes_model` model from a parent `bbi_nonmem_model` object.
+  (#84)
+
+* New `chain_paths()` helper for constructing paths to files within
+  chain sub-models.  (#104)
+
+* New `nm_join_bayes()` and `nm_join_bayes_quick()` functions provide
+  an interface for joining model output summaries to input data.
+  (#106, #116, #118, #120, #122)
+
+* Various tailored methods for `bbr` generics have been added.  (#84,
+  #123, #126, #127, #128).
+
+### Stan
+
+* New `install_torsten()` function for downloading and installing
+  [Torsten](https://github.com/metrumresearchgroup/Torsten).  (#95)
+
+* The bundled `bern-gq.stan` model has been updated to use syntax
+  compatible with Stan 2.33.  (#99)
+
+* The signature of the `submit_model()` method for Stan models did not
+  match the positional arguments of the generic.  `.bbi_args` (unused
+  for Stan models) has been added as the second argument.  (#132)
+
+
 # bbr.bayes 0.1.1
 
 ## Changes

--- a/R/nm-join-bayes.R
+++ b/R/nm-join-bayes.R
@@ -339,20 +339,9 @@ prepare_join <- function(mod, join_col, files, superset, point_fn, ...) {
   # nm_join_origin records the source of different columns.
   origin <- attr(dfs[[1]], "nm_join_origin")
   if (is.null(origin)) {
-    # For older bbr versions, fall back to peeking at the header and making the
-    # same transformations as nm_join/nm_data/nm_file.
-    #
-    # TODO: Remove when minimum bbr version is above 1.7.0.
-    smod1_data <- bbr::get_data_path(read_model(get_chain_dirs(mod)[1]))
-    data_cols <- toupper(fread_peek_at_columns(smod1_data, skip = join_col))
-
-    dv <- data_cols == "DV"
-    if (any(dv)) {
-      data_cols[dv] <- "DV.DATA"
-    }
-  } else {
-    data_cols <- origin$data
+    stop("bug: nm_join() result should have nm_join_origin attribute")
   }
+  data_cols <- origin$data
 
   data <- dfs[[1]][data_cols]
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@
 
 `bbr.bayes` is an extension to the [bbr] package for Bayesian
 modeling.  The package is in the early stages of development.  Initial
-support has been added for [Stan] models (powered by [cmdstanr]).
-Upcoming releases will extend Stan support and add support for NONMEM
-Bayes models.
+support has been added for [Stan] models (powered by [cmdstanr]) and
+for NONMEM Bayes models.
 
 ## Installation
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -37,10 +37,6 @@ reference:
   - install_torsten
 
 - title: NONMEM Bayes
-  desc: >
-    Warning: NONMEM Bayes support is incomplete, and backward
-    incompatible changes are planned.  Please use only for
-    experimentation and development.
   contents:
   - bbr_nmbayes
   - model_summary.bbi_nmbayes_model

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -39,13 +39,19 @@ reference:
 - title: NONMEM Bayes
   contents:
   - bbr_nmbayes
-  - model_summary.bbi_nmbayes_model
+- subtitle: Preparing and submitting models
+  contents:
   - copy_model_as_nmbayes
   - nmbayes_submit_model
-  - nmbayes_check_nonmem_finished
+- subtitle: Model inspection
+  contents:
   - chain_paths
-  - nmbayes_tail
+  - model_summary.bbi_nmbayes_model
   - nm_join_bayes
+  - nmbayes_tail
+- subtitle: Miscellaneous
+  contents:
+  - nmbayes_check_nonmem_finished
 
 - title: Shared utilities
   contents:


### PR DESCRIPTION
In addition to the normal release bits, this PR

 * bumps bbr dependency to latest release

 * updates the pkgdown config

 * updates a few docs to reflect the new nmbayes support

changeset: <https://github.com/metrumresearchgroup/bbr.bayes/compare/0.1.1...release/0.2.0>

<details>
<summary>mpn.scorecard scores</summary>

```json
{
  "testing": {
    "check": 0.9,
    "covr": 0.9287
  },
  "documentation": {
    "has_vignettes": 1,
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```

```
$ git rev-parse HEAD^{tree}
8f994d98bde27bf8ba72b65a913a667426daf3d8
```

</details>

