### PR TITLE
nmbayes get_data_path: rename arg to match generic

### DIFF
--- a/R/get-path-from-object.R
+++ b/R/get-path-from-object.R
@@ -25,8 +25,8 @@ get_config_path.bbi_nmbayes_model <- function(.bbi_object, .check_exists = TRUE)
 }
 
 #' @export
-get_data_path.bbi_nmbayes_model <- function(.mod, ...) {
-  mod_init_path <- file.path(get_output_dir(.mod), "init")
+get_data_path.bbi_nmbayes_model <- function(.bbi_object, ...) {
+  mod_init_path <- file.path(get_output_dir(.bbi_object), "init")
   if (!fs::file_exists(paste0(mod_init_path, ".yaml"))) {
     stop("Cannot extract data path because init submodel doesn't exist.",
          "\nThis is expected if the model has not been executed yet.")


### PR DESCRIPTION
In bbr 1.10.0, the .mod argument of get_data_path() was renamed to .bbi_object.  The argument in the get_data_path.bbi_nmbayes_model() method should have been renamed too for consistency.

This is flagged under newer versions of R:

    checking S3 generic/method consistency ... WARNING
    get_data_path:
      function(.bbi_object, .check_exists, ...)
    get_data_path.bbi_nmbayes_model:
      function(.mod, ...)