### PR TITLE
nmbayes: check_nonmem_finished updates for upcoming bbr

### DIFF
--- a/R/check-nonmem-finished.R
+++ b/R/check-nonmem-finished.R
@@ -4,9 +4,8 @@
 #' Bayes models. To decide if a model is finished, it runs
 #' [bbr::check_nonmem_finished()] on each of the chain submodels.
 #'
-#' Note that, like the `bbi_nonmem_model` method, this method is intended to be
-#' called on models that have been submitted. It happens to also return `TRUE`
-#' for un-submitted models, but that should be considered undefined behavior.
+#' As with regular NONMEM models, the model is _not_ considered finished if the
+#' output directory does not exist.
 #'
 #' @param .mod A `bbi_nmbayes_model` object.
 #' @param ... Arguments passed to method call on each chain submodel.
@@ -17,12 +16,7 @@
 check_nonmem_finished.bbi_nmbayes_model <- function(.mod, ...) {
   outdir <- get_output_dir(.mod, .check_exists = FALSE)
   if (!fs::dir_exists(outdir)) {
-    # check_nonmem_finished.bbi_nonmem_model() takes this as an indication that
-    # submission failed right away. For nmbayes model the top-level output
-    # directory is created synchronously even when `.wait = FALSE`. So it is
-    # likely a model without an output directory just wasn't submitted, but
-    # return `TRUE` for consistency.
-    return(TRUE)
+    return(FALSE)
   }
 
   subs <- purrr::map(get_chain_dirs(.mod), read_model)

--- a/man/nmbayes_check_nonmem_finished.Rd
+++ b/man/nmbayes_check_nonmem_finished.Rd
@@ -22,7 +22,6 @@ Bayes models. To decide if a model is finished, it runs
 \code{\link[bbr:check_nonmem_finished]{bbr::check_nonmem_finished()}} on each of the chain submodels.
 }
 \details{
-Note that, like the \code{bbi_nonmem_model} method, this method is intended to be
-called on models that have been submitted. It happens to also return \code{TRUE}
-for un-submitted models, but that should be considered undefined behavior.
+As with regular NONMEM models, the model is \emph{not} considered finished if the
+output directory does not exist.
 }

--- a/tests/testthat/test-check-nonmem-finished.R
+++ b/tests/testthat/test-check-nonmem-finished.R
@@ -5,7 +5,7 @@ test_that("check_nonmem_finished(): finished nmbayes model", {
 test_that("check_nonmem_finished(): no output directory", {
   tdir <- local_test_dir()
   mod <- copy_model_from(NMBAYES_MOD1, file.path(tdir, "foo"))
-  expect_true(check_nonmem_finished(mod))
+  expect_false(check_nonmem_finished(mod))
 })
 
 test_that("check_nonmem_finished() works: sequence", {

--- a/tests/testthat/test-check-nonmem-finished.R
+++ b/tests/testthat/test-check-nonmem-finished.R
@@ -14,6 +14,12 @@ test_that("check_nonmem_finished() works: sequence", {
 
   expect_false(check_nonmem_finished(mod))
 
+  # For plain NONMEM models under bbr v1.10.0 and earlier,
+  # check_nonmem_finished() looks for "Stop Time" in the lst file to decide if a
+  # model is finished. After that, the existence of bbi_config.json is used
+  # instead. Once the minimum bbr version is at least 1.11.0, the lst setup
+  # below can be dropped.
+
   cat("", file = file.path("foo", "foo-1", "foo-1.lst"))
   expect_false(check_nonmem_finished(mod))
 
@@ -21,8 +27,10 @@ test_that("check_nonmem_finished() works: sequence", {
   expect_false(check_nonmem_finished(mod))
 
   cat("Stop Time", file = file.path("foo", "foo-2", "foo-2.lst"))
+  cat("", file = file.path("foo", "foo-2", "bbi_config.json"))
   expect_false(check_nonmem_finished(mod))
 
   cat("Stop Time", file = file.path("foo", "foo-1", "foo-1.lst"))
+  cat("", file = file.path("foo", "foo-1", "bbi_config.json"))
   expect_true(check_nonmem_finished(mod))
 })


### PR DESCRIPTION
 * update test setup for `check_nonmem_finished` now using the existence of `bbi_config.json`, rather than "Stop Time" in the lst file, as the indicator that a NONMEM model is finished 
 * follow bbr's change in behavior for the "missing output directory" case