### PR TITLE
chain_paths: escape braces in docs

### DIFF
--- a/R/nmbayes-helpers.R
+++ b/R/nmbayes-helpers.R
@@ -36,7 +36,7 @@ get_chain_dirs <- function(.mod) {
 #'
 #' @param .mod A `bbi_nmbayes_model` object.
 #' @param name Name of file, without leading path or extension. If unspecified,
-#'   defaults to "{id}-{chain}".
+#'   defaults to "\{id\}-\{chain\}".
 #' @param extension File extension.
 #' @return Absolute file paths, one for each chain.
 #' @seealso [bbr_nmbayes] for a high-level description of how NONMEM Bayes

--- a/man/chain_paths.Rd
+++ b/man/chain_paths.Rd
@@ -10,7 +10,7 @@ chain_paths(.mod, name = NULL, extension = "")
 \item{.mod}{A \code{bbi_nmbayes_model} object.}
 
 \item{name}{Name of file, without leading path or extension. If unspecified,
-defaults to "{id}-{chain}".}
+defaults to "\{id\}-\{chain\}".}
 
 \item{extension}{File extension.}
 }


### PR DESCRIPTION
Escape braces so that this is rendered as "{id}-{chain}", as intended, not "id-chain".

Closes #149.