### PR TITLE
nmbayes: align get_data_path handling with bbr >= 1.10.0

### DIFF
--- a/R/get-path-from-object.R
+++ b/R/get-path-from-object.R
@@ -31,7 +31,7 @@ get_data_path.bbi_nmbayes_model <- function(.bbi_object, ...) {
     return(NextMethod())
   }
 
-  return(get_data_path(read_model(mod_init_path)))
+  return(get_data_path(read_model(mod_init_path), ...))
 }
 
 #' @export

--- a/R/get-path-from-object.R
+++ b/R/get-path-from-object.R
@@ -26,10 +26,9 @@ get_config_path.bbi_nmbayes_model <- function(.bbi_object, .check_exists = TRUE)
 
 #' @export
 get_data_path.bbi_nmbayes_model <- function(.bbi_object, ...) {
-  mod_init_path <- file.path(get_output_dir(.bbi_object), "init")
+  mod_init_path <- file.path(get_output_dir(.bbi_object, .check_exists = FALSE), "init")
   if (!fs::file_exists(paste0(mod_init_path, ".yaml"))) {
-    stop("Cannot extract data path because init submodel doesn't exist.",
-         "\nThis is expected if the model has not been executed yet.")
+    return(NextMethod())
   }
 
   return(get_data_path(read_model(mod_init_path)))

--- a/tests/testthat/test-get-path-from-object.R
+++ b/tests/testthat/test-get-path-from-object.R
@@ -41,6 +41,22 @@ test_that("nmbayes: get_data_path() parses model object", {
                                package = "bbr.bayes"))
 })
 
+test_that("nmbayes: get_data_path() falls back to control stream path", {
+  tdir <- local_test_dir()
+  model_dir <- file.path(tdir, "model", "nonmem", "bayes")
+  fs::dir_create(model_dir)
+
+  mod <- copy_model_from(NMBAYES_MOD1, file.path(model_dir, get_model_id(NMBAYES_MOD1)))
+  data_path <- file.path(tdir, "extdata", "analysis3.csv")
+
+  expect_error(get_data_path(mod), "does not exist")
+  expect_identical(get_data_path(mod, .check_exists = FALSE), data_path)
+
+  fs::dir_create(file.path(tdir, "extdata"))
+  cat("", file = data_path)
+  expect_identical(get_data_path(mod), data_path)
+})
+
 ### Stan
 
 test_that("stan: get_model_path() builds the right path", {

--- a/tests/testthat/test-get-path-from-object.R
+++ b/tests/testthat/test-get-path-from-object.R
@@ -41,6 +41,38 @@ test_that("nmbayes: get_data_path() parses model object", {
                                package = "bbr.bayes"))
 })
 
+test_that("nmbayes: get_data_path() supports .check_exists", {
+  tdir <- local_test_dir()
+
+  model_dir <- file.path(tdir, "model", "nonmem", "bayes")
+  fs::dir_create(model_dir)
+  fs::dir_copy(
+    system.file(
+      "model", "nonmem", "bayes", "1100",
+      package = "bbr.bayes", mustWork = TRUE
+    ),
+    model_dir
+  )
+  fs::file_copy(
+    system.file(
+      "model", "nonmem", "bayes", c("1100.ctl", "1100.yaml"),
+      package = "bbr.bayes", mustWork = TRUE
+    ),
+    model_dir
+  )
+
+  mod <- read_model(file.path(model_dir, "1100"))
+  expect_error(get_data_path(mod), "does not exist")
+
+  data_dir <- file.path(tdir, "extdata")
+  data_path <- file.path(data_dir, "analysis3.csv")
+  expect_identical(get_data_path(mod, .check_exists = FALSE), data_path)
+
+  fs::dir_create(data_dir)
+  cat("", file = data_path)
+  expect_identical(get_data_path(mod), data_path)
+})
+
 test_that("nmbayes: get_data_path() falls back to control stream path", {
   tdir <- local_test_dir()
   model_dir <- file.path(tdir, "model", "nonmem", "bayes")


### PR DESCRIPTION
As of bbr.bayes 0.2.0, we require at least bbr 1.10.0.  `get_data_path.bbi_nmbayes_model()` should have been updated to match changes to bbr's `get_data_path`:

 * fall back to data path from control stream if `bbi_config.json` doesn't exist

 * account for new `.check_exists` argument

This PR makes those updates.
