### PR TITLE
Prepare 0.2.1 release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,9 @@ jobs:
           - os: ubuntu-20.04
             r: 4.0.5
           - os: ubuntu-20.04
-            r: 4.1.3
+            r: 4.2.3
+          - os: ubuntu-20.04
+            r: 4.3.1
           - os: ubuntu-latest
             r: release
           - label: bbr-main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr.bayes
 Title: Bayesian modeling with BBR
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: 
     c(person(given = "Seth",
              family = "Green",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# bbr.bayes 0.2.1
+
+## Changes
+
+* `check_nonmem_finished.bbi_nmbayes_model()` now returns `FALSE` if
+  the output directory doesn't exist, following a `bbr` v1.11.0 change
+  in behavior. (#150)
+
+* The nmbayes `get_data_path()` method has been updated to follow
+  changes in `bbr` v1.10.0.
+
+  * The first argument has been renamed from `.mod` to `.bbi_object`.
+    (#138)
+
+  * The `.check_exists` argument is now supported.  (#152)
+
+  * A data path is now extracted from the control stream if the model
+    has not yet finished.  (#152)
+
+
 # bbr.bayes 0.2.0
 
 ## New features and changes


### PR DESCRIPTION
In addition to the normal release bits, this PR updates the GitHub Actions R versions to include the R versions from the latest Metworx AMI, dropping the 4.1 job but keeping the 4.0 one.

changeset: <https://github.com/metrumresearchgroup/bbr.bayes/compare/0.2.0...release/0.2.1>
