### PR TITLE
Resolve CI failures related to external updates

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,12 @@ jobs:
         config:
           - os: ubuntu-20.04
             r: 4.0.5
+            # distributional 0.5.0 started using the native pipe
+            # (introduced in R 4.1).
+            distributional_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2024-06-12/src/contrib/distributional_0.4.0.tar.gz'
+            # actuar is a suggested package for distributional. actuar
+            # v3.1-3 requires R 4.1 (through use of log1mexp).
+            actuar_pkg: 'url::https://packagemanager.posit.co/cran/latest/src/contrib/Archive/actuar/actuar_3.1-2.tar.gz'
           - os: ubuntu-20.04
             r: 4.2.3
           - os: ubuntu-20.04
@@ -56,7 +62,9 @@ jobs:
             any::pkgdown
             any::rcmdcheck
             ${{ env.BBR_PKG }}
-          upgrade: 'TRUE'
+            ${{ matrix.config.distributional_pkg }}
+            ${{ matrix.config.actuar_pkg }}
+          upgrade: ${{ matrix.config.r == '4.0.5' && 'FALSE' || 'TRUE' }}
       - name: Install cmdstan
         uses: ./.github/actions/setup-cmdstan
       - uses: r-lib/actions/check-r-package@v2

--- a/R/install_torsten.R
+++ b/R/install_torsten.R
@@ -75,6 +75,9 @@ install_torsten <- function(dir = NULL,
   ##.  M1 Macs. Is this needed?
   ## * install_torsten does not provide support for WSL. Should it?
 
+  checkmate::assert_string(dir, null.ok = TRUE)
+  checkmate::assert_string(version, null.ok = TRUE)
+
   if (isTRUE(check_toolchain)) {
     cmdstanr::check_cmdstan_toolchain(fix = FALSE, quiet = quiet)
   }

--- a/R/install_torsten.R
+++ b/R/install_torsten.R
@@ -162,7 +162,7 @@ get_torsten_download_url <- function(version, release_url) {
     }
 
     release_list <- get_torsten_release_list()
-    release <- release_list[grep(version, release_list, fixed = TRUE)]
+    release <- intersect(expand_torsten_version(version), release_list)
     if(length(release) < 1){
       stop("Available Torsten versions do not include ", version, call. = FALSE)
     }
@@ -185,6 +185,21 @@ get_torsten_download_url <- function(version, release_url) {
   }
 
   return(download_url)
+}
+
+# Expand a Torsten version, spelled as "torsten_vX.Y.Z*", "torsten_X.Y.Z*",
+# "vX.Y.Z*", or "X.Y.Z*", into a vector of all permitted variants.
+expand_torsten_version <- function(version) {
+  version <- stringr::str_remove(version, "^torsten_")
+  version <- stringr::str_remove(version, "^v")
+  return(
+    c(
+      paste0("torsten_v", version),
+      paste0("torsten_", version),
+      paste0("v", version),
+      version
+    )
+  )
 }
 
 check_install_dir <- function(dir_torsten, overwrite = FALSE) {

--- a/tests/testthat/helper-test-dir.R
+++ b/tests/testthat/helper-test-dir.R
@@ -26,7 +26,12 @@ local_stan_bern_model <- function(clean = TRUE, .local_envir = parent.frame()) {
   tdir <- local_test_dir(clean = clean, .local_envir = .local_envir)
   mdir <- file.path(tdir, "model", "stan")
   fs::dir_create(mdir)
-  copy_model_from(STAN_MOD3, file.path(mdir, "bern"))
+
+  mod <- read_model(
+    system.file("model", "stan", "bern", package = "bbr.bayes", mustWork = TRUE)
+  )
+  copy_model_from(mod, file.path(mdir, "bern"))
+
   withr::local_dir(tdir, .local_envir = .local_envir)
 }
 

--- a/tests/testthat/test-install-torsten.R
+++ b/tests/testthat/test-install-torsten.R
@@ -70,10 +70,6 @@ test_that("install_torsten() errors if invalid version or URL", {
     ),
     "cmdstanr supports installing from .tar.gz archives only"
   )
-  expect_error(
-    install_torsten_maybe_skip(dir = tdir, quiet = TRUE, version = "0"),
-    "matches multiple"
-  )
 })
 
 test_that("install_torsten() overwrite check works", {
@@ -137,4 +133,29 @@ test_that("install_torsten() works with version and release_url", {
     get_torsten_download_url_maybe_skip(version = NULL, release_url = NULL)
   )
   expect_true(v_latest > url_to_version(torsten_test_tarball_url_default))
+})
+
+test_that("expand_torsten_version() works", {
+  for (v in c("torsten_v1.2.3", "torsten_1.2.3", "v1.2.3", "1.2.3")) {
+    expect_identical(
+      expand_torsten_version(!!v),
+      c(
+        "torsten_v1.2.3",
+        "torsten_1.2.3",
+        "v1.2.3",
+        "1.2.3"
+      )
+    )
+  }
+  for (v in c("torsten_v1.2.3rc0", "torsten_1.2.3rc0", "v1.2.3rc0", "1.2.3rc0")) {
+    expect_identical(
+      expand_torsten_version(!!v),
+      c(
+        "torsten_v1.2.3rc0",
+        "torsten_1.2.3rc0",
+        "v1.2.3rc0",
+        "1.2.3rc0"
+      )
+    )
+  }
 })

--- a/tests/testthat/test-install-torsten.R
+++ b/tests/testthat/test-install-torsten.R
@@ -1,6 +1,9 @@
 ## Adapted from test-install.R from the cmdstanr package
 
-torsten_test_tarball_url_default <- paste0(TORSTEN_URL_BASE, "torsten_v0.89.1.tar.gz")
+torsten_version <- "0.89.1" # version used for actual installation
+torsten_test_tarball_url_default <- paste0(
+  TORSTEN_URL_BASE, "torsten_v", torsten_version, ".tar.gz"
+)
 torsten_test_tarball_url <- Sys.getenv("TORSTEN_TEST_TARBALL_URL")
 if (!nzchar(torsten_test_tarball_url)) {
   torsten_test_tarball_url <- torsten_test_tarball_url_default
@@ -100,18 +103,21 @@ test_that("install_torsten() overwrite check works", {
 
 test_that("install_torsten() works with version and release_url", {
   expect_identical(
-    get_torsten_download_url_maybe_skip(version = "0.89.1", release_url = NULL),
+    get_torsten_download_url_maybe_skip(version = torsten_version, release_url = NULL),
     torsten_test_tarball_url_default
   )
 
   expect_identical(
-    get_torsten_download_url_maybe_skip(version = "torsten_v0.89.1", release_url = NULL),
+    get_torsten_download_url_maybe_skip(
+      version = paste0("torsten_v", torsten_version),
+      release_url = NULL
+    ),
     torsten_test_tarball_url_default
   )
 
   expect_warning(
     res <- get_torsten_download_url_maybe_skip(
-      version = "0.89.1",
+      version = torsten_version,
       # the URL is intentionally invalid to test that the version has higher priority
       release_url = paste0(TORSTEN_URL_BASE, "torsten_v0.89.3.tar.gz")
     ),

--- a/tests/testthat/test-install-torsten.R
+++ b/tests/testthat/test-install-torsten.R
@@ -1,8 +1,8 @@
 ## Adapted from test-install.R from the cmdstanr package
 
-torsten_version <- "0.89.1" # version used for actual installation
+torsten_version <- "0.91.0" # version used for actual installation
 torsten_test_tarball_url_default <- paste0(
-  TORSTEN_URL_BASE, "torsten_v", torsten_version, ".tar.gz"
+  TORSTEN_URL_BASE, "v", torsten_version, ".tar.gz"
 )
 torsten_test_tarball_url <- Sys.getenv("TORSTEN_TEST_TARBALL_URL")
 if (!nzchar(torsten_test_tarball_url)) {
@@ -138,7 +138,12 @@ test_that("install_torsten() works with version and release_url", {
   v_latest <- url_to_version(
     get_torsten_download_url_maybe_skip(version = NULL, release_url = NULL)
   )
-  expect_true(v_latest > url_to_version(torsten_test_tarball_url_default))
+  # Ideally the torsten_test_tarball_url_default version would not be the latest
+  # version so that get_torsten_download_url() and
+  # get_torsten_download_url(version = N) would return different results (i.e.
+  # we could use ">" rather than ">=" below). However, at the moment (2025-02),
+  # the latest version is 0.91.0 and earlier ones fail to build on ubuntu-24.04.
+  expect_true(v_latest >= url_to_version(torsten_test_tarball_url_default))
 })
 
 test_that("expand_torsten_version() works", {


### PR DESCRIPTION
This PR originally started out as an update to the `local_stan_bern_mode` to make it compatible with a change in testthat v3.2.2.  However, the CI was failing for a couple of other reasons:

 * dependency updates that are incompatible with the R 4.0 check

 * the Torsten **v0.89.1** installation fails on Ubuntu 24.04.

   Updating to v0.91.0 resolves that failure, but doing that revealed an issue with `install_torsten`s version selection.

So this PR has turned into a more general "get the CI green" PR.
