### PR TITLE
submit_model: Fix .overwrite documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -74,4 +74,4 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -27,7 +27,7 @@ submit_model.bbi_nmbayes_model <- function(
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
   ...,
-  .overwrite = NULL,
+  .overwrite = FALSE,
   .config_path = NULL,
   .wait = TRUE,
   .dry_run = FALSE
@@ -126,7 +126,7 @@ submit_model.bbi_stan_model <- function(
   .bbi_args = NULL,
   .mode = c("local"),
   ...,
-  .overwrite = NULL
+  .overwrite = FALSE
 ) {
   rlang::check_dots_empty()
   if (!is.null(.bbi_args)) {
@@ -144,7 +144,7 @@ submit_model.bbi_stan_model <- function(
 #' @rdname stan_submit_model
 #' @export
 submit_model.bbi_stan_gq_model <- function(.mod, .bbi_args = NULL, .mode = c("local"),
-                                           ..., .overwrite = NULL) {
+                                           ..., .overwrite = FALSE) {
   rlang::check_dots_empty()
   if (!is.null(.bbi_args)) {
     stop(".bbi_args must be NULL for model_type=stan_gq")
@@ -178,7 +178,7 @@ submit_model.bbi_stan_gq_model <- function(.mod, .bbi_args = NULL, .mode = c("lo
 submit_stan_model_cmdstanr <- function(.mod,
                                        .method = c("sample", "generate_quantities"),
                                        .mode = c("local"), # TODO: add sge mode for cmdstanr
-                                       .overwrite = NULL) {
+                                       .overwrite = FALSE) {
 
   # check against YAML
   check_yaml_in_sync(.mod)

--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -8,6 +8,10 @@
 #' `METHOD=NUTS` runs).
 #'
 #' @name nmbayes_submit_model
+#' @param .overwrite Whether to overwrite an existing output directory. Note
+#'   that, unlike the submission method for regular `bbi_nonmem_model` objects,
+#'   this method does not inspect `.bbi_args` or `bbi.yaml` when the value is
+#'   `NULL`; any value other than `TRUE` is treated the same as `FALSE`.
 #' @param .dry_run Do not submit the sampling runs; just report what command
 #'   would be executed via the returned object. **Note**: The METHOD=CHAIN model
 #'   is executed to generate the initialization values regardless of this value.
@@ -107,6 +111,10 @@ submit_model.bbi_nmbayes_model <- function(
 #' @param .mode Mode of model submission. Stan models currently only support
 #'   local execution.
 #' @param ... Additional arguments (ignored for all Stan models).
+#' @param .overwrite Whether to overwrite an existing output directory. Note
+#'   that, unlike the submission method for regular `bbi_nonmem_model` objects,
+#'   this method does not inspect `.bbi_args` or `bbi.yaml` when the value is
+#'   `NULL`; any value other than `TRUE` is treated the same as `FALSE`.
 #' @seealso [bbr_stan] for a high-level description of how Stan models are
 #'   structured
 NULL

--- a/man/nmbayes_check_nonmem_finished.Rd
+++ b/man/nmbayes_check_nonmem_finished.Rd
@@ -17,9 +17,9 @@
 otherwise.
 }
 \description{
-This function implements the \code{\link[bbr:check_nonmem_finished]{bbr::check_nonmem_finished()}} method for NONMEM
+This function implements the \code{\link[bbr:model_status]{bbr::check_nonmem_finished()}} method for NONMEM
 Bayes models. To decide if a model is finished, it runs
-\code{\link[bbr:check_nonmem_finished]{bbr::check_nonmem_finished()}} on each of the chain submodels.
+\code{\link[bbr:model_status]{bbr::check_nonmem_finished()}} on each of the chain submodels.
 }
 \details{
 As with regular NONMEM models, the model is \emph{not} considered finished if the

--- a/man/nmbayes_submit_model.Rd
+++ b/man/nmbayes_submit_model.Rd
@@ -30,14 +30,10 @@ option. This option defaults to "sge" on Linux and "local" otherwise.}
 
 \item{...}{args passed through to \code{bbi_exec()}}
 
-\item{.overwrite}{Logical to specify whether or not to overwrite existing
-model output from a previous run. If \code{NULL}, the default, will defer to
-setting in \code{.bbi_args} or \code{bbi.yaml}. If \emph{not} \code{NULL} will override any
-settings in \code{.bbi_args} or \code{bbi.yaml}. \strong{The exception to this are
-bootstrap runs (\code{bbi_nmboot_model} objects).} For bootstrap runs, this
-defaults to \code{FALSE} and does \emph{not} respect any setting passed via
-\code{.bbi_args} or a \code{bbi.yaml} config file. To overwrite existing bootstrap
-output, a user must pass \code{TRUE} through this argument.}
+\item{.overwrite}{Whether to overwrite an existing output directory. Note
+that, unlike the submission method for regular \code{bbi_nonmem_model} objects,
+this method does not inspect \code{.bbi_args} or \code{bbi.yaml} when the value is
+\code{NULL}; any value other than \code{TRUE} is treated the same as \code{FALSE}.}
 
 \item{.config_path}{Path to a bbi configuration file. If \code{NULL}, the
 default, will attempt to use a \code{bbi.yaml} in the same directory as the

--- a/man/nmbayes_submit_model.Rd
+++ b/man/nmbayes_submit_model.Rd
@@ -10,7 +10,7 @@
   .bbi_args = NULL,
   .mode = getOption("bbr.bbi_exe_mode"),
   ...,
-  .overwrite = NULL,
+  .overwrite = FALSE,
   .config_path = NULL,
   .wait = TRUE,
   .dry_run = FALSE

--- a/man/nmbayes_submit_model.Rd
+++ b/man/nmbayes_submit_model.Rd
@@ -24,16 +24,20 @@ formatted like \code{list("nm_version" = "nm74gf_nmfe", "json" = T, "threads" = 
 not support changing the output directory (including through the model or
 global YAML files).}
 
-\item{.mode}{Either \code{"sge"}, the default, to submit model(s) to the grid or
-\code{"local"} for local execution. This can be passed directly to this argument
-or set globally with \code{options("bbr.bbi_exe_mode")}.}
+\item{.mode}{Mode for model submission: "local", "sge", or "slurm". If
+unspecified, the value is set to the value of the \code{bbr.bbi_exe_mode}
+option. This option defaults to "sge" on Linux and "local" otherwise.}
 
 \item{...}{args passed through to \code{bbi_exec()}}
 
 \item{.overwrite}{Logical to specify whether or not to overwrite existing
 model output from a previous run. If \code{NULL}, the default, will defer to
 setting in \code{.bbi_args} or \code{bbi.yaml}. If \emph{not} \code{NULL} will override any
-settings in \code{.bbi_args} or \code{bbi.yaml}.}
+settings in \code{.bbi_args} or \code{bbi.yaml}. \strong{The exception to this are
+bootstrap runs (\code{bbi_nmboot_model} objects).} For bootstrap runs, this
+defaults to \code{FALSE} and does \emph{not} respect any setting passed via
+\code{.bbi_args} or a \code{bbi.yaml} config file. To overwrite existing bootstrap
+output, a user must pass \code{TRUE} through this argument.}
 
 \item{.config_path}{Path to a bbi configuration file. If \code{NULL}, the
 default, will attempt to use a \code{bbi.yaml} in the same directory as the

--- a/man/stan_submit_model.Rd
+++ b/man/stan_submit_model.Rd
@@ -11,7 +11,7 @@
   .bbi_args = NULL,
   .mode = c("local"),
   ...,
-  .overwrite = NULL
+  .overwrite = FALSE
 )
 
 \method{submit_model}{bbi_stan_gq_model}(
@@ -19,7 +19,7 @@
   .bbi_args = NULL,
   .mode = c("local"),
   ...,
-  .overwrite = NULL
+  .overwrite = FALSE
 )
 }
 \arguments{

--- a/man/stan_submit_model.Rd
+++ b/man/stan_submit_model.Rd
@@ -36,7 +36,11 @@ local execution.}
 \item{.overwrite}{Logical to specify whether or not to overwrite existing
 model output from a previous run. If \code{NULL}, the default, will defer to
 setting in \code{.bbi_args} or \code{bbi.yaml}. If \emph{not} \code{NULL} will override any
-settings in \code{.bbi_args} or \code{bbi.yaml}.}
+settings in \code{.bbi_args} or \code{bbi.yaml}. \strong{The exception to this are
+bootstrap runs (\code{bbi_nmboot_model} objects).} For bootstrap runs, this
+defaults to \code{FALSE} and does \emph{not} respect any setting passed via
+\code{.bbi_args} or a \code{bbi.yaml} config file. To overwrite existing bootstrap
+output, a user must pass \code{TRUE} through this argument.}
 }
 \description{
 Run the model via \pkg{cmdstanr}, selecting the \code{CmdStanModel} method based

--- a/man/stan_submit_model.Rd
+++ b/man/stan_submit_model.Rd
@@ -33,14 +33,10 @@ local execution.}
 
 \item{...}{Additional arguments (ignored for all Stan models).}
 
-\item{.overwrite}{Logical to specify whether or not to overwrite existing
-model output from a previous run. If \code{NULL}, the default, will defer to
-setting in \code{.bbi_args} or \code{bbi.yaml}. If \emph{not} \code{NULL} will override any
-settings in \code{.bbi_args} or \code{bbi.yaml}. \strong{The exception to this are
-bootstrap runs (\code{bbi_nmboot_model} objects).} For bootstrap runs, this
-defaults to \code{FALSE} and does \emph{not} respect any setting passed via
-\code{.bbi_args} or a \code{bbi.yaml} config file. To overwrite existing bootstrap
-output, a user must pass \code{TRUE} through this argument.}
+\item{.overwrite}{Whether to overwrite an existing output directory. Note
+that, unlike the submission method for regular \code{bbi_nonmem_model} objects,
+this method does not inspect \code{.bbi_args} or \code{bbi.yaml} when the value is
+\code{NULL}; any value other than \code{TRUE} is treated the same as \code{FALSE}.}
 }
 \description{
 Run the model via \pkg{cmdstanr}, selecting the \code{CmdStanModel} method based


### PR DESCRIPTION
In https://github.com/metrumresearchgroup/bbr/pull/692 ([de1a73f9](https://github.com/metrumresearchgroup/bbr/commit/de1a73f9cb4007ea9fa041849092799f9b03e979)), @seth127 pointed out that the `.overwrite` behavior for the nmbayes `submit_model`method  was undocumented.  This PR addresses that by adding a custom `.overwrite` description for `submit_model.bbi_nmbayes_model` method rather than inheriting the `.overwrite` description from `bbr::submit_model`.

The same fix is also made for the `stan` method, and the default value of both methods is switched from `NULL` to `FALSE` to more clearly communicate the default behavior.

---

- [x] wait for the merge of the base PRs (gh-159, gh-160)
