### PR TITLE
nmbayes submit_model: ensure inits are generated synchronously

### DIFF
--- a/R/submit-model.R
+++ b/R/submit-model.R
@@ -61,9 +61,9 @@ submit_model.bbi_nmbayes_model <- function(
     .bbi_args = .bbi_args,
     .overwrite = TRUE,
     .config_path = .config_path,
-    .wait = .wait,
-    # Regardless of the mode for the main sampling (triggered by run_chains),
-    # this upfront initialization should always be done locally.
+    # Always generate the inits synchronously, regardless of the
+    # caller-specified values for .wait and .mode.
+    .wait = TRUE,
     .mode = "local",
     .dry_run = FALSE)
 

--- a/tests/testthat/test-workflow-nmbayes.R
+++ b/tests/testthat/test-workflow-nmbayes.R
@@ -101,3 +101,16 @@ test_that("nmbayes: summary_log() captures runs correctly", {
   expect_setequal(basename(log_df[[ABS_MOD_PATH]]),
                   c("1100", "1101", "1102"))
 })
+
+test_that("nmbayes: submit_model() generates inits synchronously", {
+  mod_parent <- read_model(file.path("model", "nonmem", "bayes", "1101"))
+  mod <- copy_model_from(mod_parent)
+  # Note: this serves as a regression test that the model submission to generate
+  # init.chn happens synchronously. It's possible for any given run of this test
+  # to miss a regression because an asynchronous init submission _could_ create
+  # init.chn before the check below fires, but that should be very unlikely.
+  res <- submit_model(mod, .mode = "sge", .wait = FALSE, .dry_run = TRUE)
+  checkmate::expect_file_exists(file.path(get_output_dir(mod), "init.chn"))
+  expect_length(res, 1)
+  expect_contains(res[[1]][["cmd_args"]], "sge")
+})


### PR DESCRIPTION
submit_model.bbi_nmbayes_model does an upfront submission of a model to generate the init.chn file that's used as input for the main sampling models.

The caller-specified .wait value is propagated to the initial model submission.  This creates a race between init.chn being created and the main sampling runs reading it in.

Do the initial submission under .wait=TRUE.

Fixes #155

---

cc: @curtisKJ @timwaterhouse

- [x] wait for the merge of the base PRs (gh-159, gh-160)
