### PR TITLE
nmbayes_draws: fix handling of THETAs with multiple digits

### DIFF
--- a/R/nmbayes-helpers.R
+++ b/R/nmbayes-helpers.R
@@ -112,12 +112,12 @@ fread_peek_at_columns <- function(file, skip = 1) {
 
 #' Rename NONMEM variables for rvar compatibility
 #'
-#' NONMEM uses labels like `THETA1` and `OMEGA(1,1)`for its flattened variables.
+#' NONMEM uses labels like `THETA1` and `OMEGA(1,1)` for its flattened variables.
 #' \pkg{posterior}, on the other hand, constructs its random variable data type
 #' with labels that use square brackets, e.g., `THETA[1]` or `OMEGA[1,1]`.
 #'
 #' @noRd
-rename_nm_as_rvar  <- function(name) {
+rename_nm_as_rvar <- function(name) {
   stringr::str_replace(name, "(.*)([0-9]+)$", "\\1[\\2]") %>%
     stringr::str_replace("(.*)\\(([,0-9]+)\\)$", "\\1[\\2]")
 }

--- a/R/nmbayes-helpers.R
+++ b/R/nmbayes-helpers.R
@@ -118,6 +118,6 @@ fread_peek_at_columns <- function(file, skip = 1) {
 #'
 #' @noRd
 rename_nm_as_rvar <- function(name) {
-  stringr::str_replace(name, "(.*)([0-9]+)$", "\\1[\\2]") %>%
+  stringr::str_replace(name, "(.*?)([0-9]+)$", "\\1[\\2]") %>%
     stringr::str_replace("(.*)\\(([,0-9]+)\\)$", "\\1[\\2]")
 }

--- a/tests/testthat/test-nmbayes-draws.R
+++ b/tests/testthat/test-nmbayes-draws.R
@@ -117,3 +117,68 @@ test_that("reshape_iph() encodes labels in parameter names: subpops", {
     res$subpop_map,
     tibble::tibble(index = 1:npops, SUBPOP = 1:npops))
 })
+
+test_that("reshape_iph() handles multi-digit parameter names", {
+  niter <- 4L
+  nsubj <- 3L
+  nobs <- niter * nsubj
+  netas <- 11L
+
+  ids <- 1:nsubj * 100L
+  data <- tibble::tibble(
+    "ITERATION" = rep(1:niter, each = nsubj),
+    "SUBJECT_NO" = rep(1:nsubj, times = niter),
+    "ID" = rep(ids, times = niter),
+    "SUBPOP" = rep(0L, nobs),
+    "ETA(1)" = 1:12,
+    "ETA(2)" = 13:24,
+    "ETA(3)" = 25:36,
+    "ETA(4)" = 37:48,
+    "ETA(5)" = 49:60,
+    "ETA(6)" = 61:72,
+    "ETA(7)" = 73:84,
+    "ETA(8)" = 85:96,
+    "ETA(9)" = 97:108,
+    "ETA(10)" = 109:120,
+    "ETA(11)" = 121:132,
+    "MCMCOBJ" = 3L
+  )
+
+  res <- reshape_iph(data)
+  draws <- res[["draws"]]
+
+  expect_identical(
+    colnames(draws),
+    c(
+      "ETA[1,1,1]", "ETA[1,1,2]", "ETA[1,1,3]",
+      "ETA[2,1,1]", "ETA[2,1,2]", "ETA[2,1,3]",
+      "ETA[3,1,1]", "ETA[3,1,2]", "ETA[3,1,3]",
+      "ETA[4,1,1]", "ETA[4,1,2]", "ETA[4,1,3]",
+      "ETA[5,1,1]", "ETA[5,1,2]", "ETA[5,1,3]",
+      "ETA[6,1,1]", "ETA[6,1,2]", "ETA[6,1,3]",
+      "ETA[7,1,1]", "ETA[7,1,2]", "ETA[7,1,3]",
+      "ETA[8,1,1]", "ETA[8,1,2]", "ETA[8,1,3]",
+      "ETA[9,1,1]", "ETA[9,1,2]", "ETA[9,1,3]",
+      "ETA[10,1,1]", "ETA[10,1,2]", "ETA[10,1,3]",
+      "ETA[11,1,1]", "ETA[11,1,2]", "ETA[11,1,3]",
+      "MCMCOBJ[1,1]", "MCMCOBJ[1,2]", "MCMCOBJ[1,3]"
+    )
+  )
+
+  rvars <- posterior::as_draws_rvars(draws)
+  expect_identical(names(rvars), c("ETA", "MCMCOBJ"))
+
+  eta <- rvars[["ETA"]]
+  expect_identical(dim(eta), c(netas, 1L, nsubj))
+
+  for (subj in seq_len(nsubj)) {
+    for (eta_idx in seq_len(netas)) {
+      eta_label <- sprintf("ETA(%d)", eta_idx)
+      data_subset <- data[data$SUBJECT_NO == subj, eta_label]
+      expect_equal(
+        as.vector(posterior::draws_of(eta[eta_idx, 1, subj])),
+        unlist(data_subset, use.names = FALSE)
+      )
+    }
+  }
+})

--- a/tests/testthat/test-nmbayes-helpers.R
+++ b/tests/testthat/test-nmbayes-helpers.R
@@ -91,3 +91,23 @@ test_that("chain_paths_impl() optionally checks existence: some missing", {
     chain_paths_impl(mod, extension = ".ext", check_exists = "all_or_none"),
     "Missing")
 })
+
+test_that("rename_nm_as_rvar works", {
+  cases <- list(
+    list(input = "THETA3", want = "THETA[3]"),
+    list(input = "THETA33", want = "THETA[33]"),
+    list(input = "THETA01", want = "THETA[01]"),
+    list(input = "OMEGA(1,1)", want = "OMEGA[1,1]"),
+    list(input = "OMEGA(12,13)", want = "OMEGA[12,13]"),
+    list(
+      input = c("THETA55", "SIGMA(60,1)"),
+      want = c("THETA[55]", "SIGMA[60,1]")
+    )
+  )
+  for (case in cases) {
+    expect_identical(
+      rename_nm_as_rvar(!!case$input),
+      !!case$want
+    )
+  }
+})


### PR DESCRIPTION
This PR fixes the `nmbayes_draws` bug that @timwaterhouse reported in gh-156.

It applies the same change from the [suggested workaround](https://github.com/metrumresearchgroup/bbr.bayes/issues/156#issuecomment-2594065245).

The second commit is the main one of interest.  The first one is cosmetic cleanup, and the second one adds an a test that checks that the iph handling (which has distinct logic from this bug) handles ETA names with multiple digits.

---

- [x] wait for the merge of the base PRs (gh-159, gh-160)

- [x] connect with @timwaterhouse to manually test and confirm that this resolves the originally reported issue
