### PR TITLE
Prepare 0.2.2 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Authors@R:
              email = "kyleb@metrumrg.com",
              comment = c(ORCID = "0000-0001-7252-5656")))
 Description: This package extends the BBR package for Bayesian modeling.
-    It adds supports for running 'Stan' models via the 'CmdStanR' interface and
+    It adds support for running 'Stan' models via the 'CmdStanR' interface and
     for running NONMEM models with Bayesian estimation methods via 'bbi'.
 License: MIT + file LICENSE
 URL: https://metrumresearchgroup.github.io/bbr.bayes, https://github.com/metrumresearchgroup/bbr.bayes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: bbr.bayes
 Title: Bayesian modeling with BBR
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: 
     c(person(given = "Seth",
              family = "Green",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,29 @@
+# bbr.bayes 0.2.2
+
+## Bug fixes
+
+* For `nmbayes` models, the `posterior::as_draws()` method
+  (`?bbr_as_draws`) and `read_fit_model()` rename variables for
+  compatibility with `?posterior::draws_rvars`.  This logic mishandled
+  `THETA` names with multiple digits (e.g., `THETA10`).  (#163)
+
+* The `submit_model()` method for `nmbayes` (`?nmbayes_submit_model`)
+  did not generate initial values synchronously when a caller passed
+  `FALSE` for `.wait`, leading to a race between creating the initial
+  values and the subsequent model runs reading those values.  (#162)
+
+* The documentation of the `submit_model()` methods for `nmbayes`
+  (`?nmbayes_submit_model`) and `stan` (`?stan_submit_model`) models
+  inherited their `.overwrite` description from `bbr::submit_model()`,
+  which inaccurately described their handling.  (#161)
+
+* `install_torsten()` aborts if the caller specifies a `version`
+  argument that doesn't uniquely identify an available version.  It
+  incorrectly aborted when the specified version was valid but a
+  sub-string of another available version (e.g., "v0.91.0" could not
+  be selected because a "v0.91.0rc2" release exists).  (#159)
+
+
 # bbr.bayes 0.2.1
 
 ## Changes


### PR DESCRIPTION
changeset: <https://github.com/metrumresearchgroup/bbr.bayes/compare/0.2.1...release/0.2.2>

<details>
<summary>scores</summary>

```
$ git rev-parse HEAD
eea3539c0e2eedf3a6fb14c2bf7f9350b7ebab39
```

```json
{
  "testing": {
    "check": 0.9,
    "coverage": 0.9292
  },
  "documentation": {
    "has_vignettes": 1,
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```

</details>
