### PR TITLE
ci: cache cmdstan install and restrict Torsten tests to cron job

### DIFF
--- a/.github/actions/setup-cmdstan/action.yaml
+++ b/.github/actions/setup-cmdstan/action.yaml
@@ -1,4 +1,3 @@
-# TODO: Investigate whether it's worthwhile to implement caching.
 name: Setup cmdstan
 description: Install cmdstan
 runs:
@@ -8,6 +7,20 @@ runs:
       shell: bash
       run: |
         echo "CMDSTAN_PATH=${HOME}/.cmdstan" >>"$GITHUB_ENV"
+    - name: Determine OS Version
+      id: find-os
+      shell: bash
+      run:
+        echo "os_id=$(lsb_release -is || :)-$(lsb_release -rs || :)" >"$GITHUB_OUTPUT"
+    - name: Cache cmdstan
+      id: cache-cmdstan
+      uses: actions/cache@v4
+      with:
+        path: ~/.cmdstan
+        key: cmdstan-${{ env.OS_ID }}
+      env:
+        OS_ID: ${{ steps.find-os.outputs.os_id }}
     - name: Install cmdstan
+      if: ${{ steps.cache-cmdstan.outputs.cache-hit != 'true' }}
       shell: Rscript {0}
       run: cmdstanr::install_cmdstan()

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,6 +8,9 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+.[0-9]+'
   pull_request:
+  schedule:
+    # Monday at 04:41
+    - cron: '41 4 * * 1'
 
 env:
   BBI_VERSION: v3.4.0
@@ -39,6 +42,7 @@ jobs:
             r: release
     env:
       R_KEEP_PKG_SOURCE: yes
+      BBR_BAYES_TESTS_SKIP_TORSTEN: yes
     steps:
       - uses: actions/checkout@v4
       - uses: metrumresearchgroup/actions/mpn-latest@v1
@@ -67,6 +71,11 @@ jobs:
           upgrade: ${{ matrix.config.r == '4.0.5' && 'FALSE' || 'TRUE' }}
       - name: Install cmdstan
         uses: ./.github/actions/setup-cmdstan
+      - name: Enable install_torsten tests for Cron job
+        if: github.event_name == 'schedule'
+        shell: bash
+        run: |
+          echo 'BBR_BAYES_TESTS_SKIP_TORSTEN=' >>"$GITHUB_ENV"
       - uses: r-lib/actions/check-r-package@v2
       - name: Check pkgdown
         shell: Rscript {0}

--- a/tests/testthat/helpers-skip.R
+++ b/tests/testthat/helpers-skip.R
@@ -5,6 +5,12 @@ skip_if_no_bbi <- function() {
   }
 }
 
+skip_if_no_cmdstan <- function() {
+  if (is.null(cmdstanr::cmdstan_version(error_on_NA = FALSE))) {
+    testthat::skip("Requires cmdstan installation")
+  }
+}
+
 # A short stretch of jsonlite versions use 17 significant digits instead of 15
 # when `digits = NA`. The data in this test suite was generated with 15-digit
 # precision.

--- a/tests/testthat/test-add-file-to-model-dir.R
+++ b/tests/testthat/test-add-file-to-model-dir.R
@@ -1,5 +1,7 @@
 context("adding files to Stan models")
 
+skip_if_no_cmdstan()
+
 test_that("add_stanmod_file() works correctly for scaffold", {
   mod_name <- "testmod_add_stanmod_file1"
   suppressMessages(

--- a/tests/testthat/test-check-stan-model.R
+++ b/tests/testthat/test-check-stan-model.R
@@ -1,5 +1,7 @@
 context("checking Stan model integrity")
 
+skip_if_no_cmdstan()
+
 test_that("check_stan_model messages missing files", {
   tdir <- local_test_dir()
   for (model_type in c("stan", "stan_gq")) {

--- a/tests/testthat/test-install-torsten.R
+++ b/tests/testthat/test-install-torsten.R
@@ -14,6 +14,7 @@ if (!nzchar(torsten_test_tarball_url)) {
 }
 
 reset_cmdstan_path <- function(envir = parent.frame()) {
+  skip_if_no_cmdstan()
   oldpath <- cmdstanr::cmdstan_path()
   withr::defer(cmdstanr::set_cmdstan_path(oldpath), envir = envir)
 }

--- a/tests/testthat/test-install-torsten.R
+++ b/tests/testthat/test-install-torsten.R
@@ -1,3 +1,7 @@
+if (!identical(Sys.getenv("BBR_BAYES_TESTS_SKIP_TORSTEN", ""), "")) {
+  testthat::skip("BBR_BAYES_TESTS_SKIP_TORSTEN is set")
+}
+
 ## Adapted from test-install.R from the cmdstanr package
 
 torsten_version <- "0.91.0" # version used for actual installation

--- a/tests/testthat/test-new-model.R
+++ b/tests/testthat/test-new-model.R
@@ -50,6 +50,8 @@ test_that("stan: new_model() errors without .model_type", {
 })
 
 test_that("stan: new_model() works", {
+  skip_if_no_cmdstan()
+
   mod_name <- "testmod_new_model2"
   expect_message(
     .m <- new_model(file.path(STAN_MODEL_DIR, mod_name), .model_type = "stan"),
@@ -64,6 +66,8 @@ test_that("stan: new_model() works", {
 })
 
 test_that("stan_gq: new_model() works", {
+  skip_if_no_cmdstan()
+
   tdir <- local_test_dir()
   expect_message(
     m <- new_model(file.path(tdir, "gq"), .model_type = "stan_gq"),

--- a/tests/testthat/test-read-fit-model.R
+++ b/tests/testthat/test-read-fit-model.R
@@ -83,6 +83,8 @@ test_that("stan gq: read_fit_model() works correctly", {
 })
 
 test_that("stan: read_fit_model() signals custom error on missing RDS", {
+  skip_if_no_cmdstan()
+
   tdir <- local_test_dir()
   mod <- new_model(tdir, .model_type = "stan")
   expect_error(read_fit_model(mod), class = "bbr.bayes_read_fit_error")

--- a/tests/testthat/test-stan-gq-parent.R
+++ b/tests/testthat/test-stan-gq-parent.R
@@ -1,3 +1,4 @@
+skip_if_no_cmdstan()
 
 test_that("gq_parent helpers abort if model type is not stan_gq", {
   mod <- bbr::new_model(local_test_dir(), .model_type = "stan")

--- a/tests/testthat/test-stan-summary-log.R
+++ b/tests/testthat/test-stan-summary-log.R
@@ -1,5 +1,6 @@
 
 skip_long_tests("skipping long-running summary_log() tests")
+skip_if_no_cmdstan()
 
 local_model_tempdir <- function(clean = TRUE, .local_envir = parent.frame()) {
   tdir <- local_test_dir(clean = clean, .local_envir = .local_envir)

--- a/tests/testthat/test-stanargs.R
+++ b/tests/testthat/test-stanargs.R
@@ -1,3 +1,5 @@
+skip_if_no_cmdstan()
+
 test_that("set_stanargs modifies file", {
   for (mod in list(STAN_MOD1, STAN_GQ_MOD)) {
     tdir <- local_test_dir()

--- a/tests/testthat/test-workflow-stan-gq.R
+++ b/tests/testthat/test-workflow-stan-gq.R
@@ -1,5 +1,6 @@
 
 skip_long_tests("skipping long-running Stan gq submit_model tests")
+skip_if_no_cmdstan()
 
 local_stan_bern_model()
 

--- a/tests/testthat/test-workflow-stan-repr.R
+++ b/tests/testthat/test-workflow-stan-repr.R
@@ -1,5 +1,6 @@
 
 skip_long_tests("skipping long-running Stan reproducibility tests")
+skip_if_no_cmdstan()
 
 local_stan_bern_model()
 

--- a/tests/testthat/test-workflow-stan.R
+++ b/tests/testthat/test-workflow-stan.R
@@ -1,6 +1,7 @@
 context("testing submitting Stan models")
 
 skip_long_tests("skipping long-running Stan submit_model tests")
+skip_if_no_cmdstan()
 
 # define constants
 MODEL_DIR_STAN_TEST <- file.path(dirname(STAN_ABS_MODEL_DIR), "test-workflow-stan-models")


### PR DESCRIPTION
This PR has two changes that bring the CI time (most recent runs have been somewhere between 11 and 16 minutes) down:

 * restrict the run of the `install_torsten` tests to a scheduled cron job

 * cache the cmdstan installation (when there's a hit, the step goes from a bit under 2 minutes to under 10 seconds)

On top of that, there's a commit to skip tests that require cmdstan if cmdstan isn't installed.  I'll push this after the build completes for the first two commits so that we have a run with the cache in effect.