### PR TITLE
CI housekeeping

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,9 +34,9 @@ jobs:
             # scales 1.4.0 requires at least R 4.1.
             scales_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-04-23/src/contrib/scales_1.3.0.tar.gz'
           - os: ubuntu-22.04
-            r: 4.2.3
+            r: 4.3.3
           - os: ubuntu-22.04
-            r: 4.3.1
+            r: 4.4.2
           - os: ubuntu-latest
             r: release
           - label: bbr-main

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -80,6 +80,8 @@ jobs:
         run: |
           echo 'BBR_BAYES_TESTS_SKIP_TORSTEN=' >>"$GITHUB_ENV"
       - uses: r-lib/actions/check-r-package@v2
+        with:
+          error-on: ${{ matrix.config.r == 'release' && '"note"' || '"warning"' }}
       - name: Check pkgdown
         shell: Rscript {0}
         run: pkgdown::check_pkgdown()

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,6 +31,8 @@ jobs:
             # actuar is a suggested package for distributional. actuar
             # v3.1-3 requires R 4.1 (through use of log1mexp).
             actuar_pkg: 'url::https://packagemanager.posit.co/cran/latest/src/contrib/Archive/actuar/actuar_3.1-2.tar.gz'
+            # scales 1.4.0 requires at least R 4.1.
+            scales_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-04-23/src/contrib/scales_1.3.0.tar.gz'
           - os: ubuntu-22.04
             r: 4.2.3
           - os: ubuntu-22.04
@@ -68,6 +70,7 @@ jobs:
             ${{ env.BBR_PKG }}
             ${{ matrix.config.distributional_pkg }}
             ${{ matrix.config.actuar_pkg }}
+            ${{ matrix.config.scales_pkg }}
           upgrade: ${{ matrix.config.r == '4.0.5' && 'FALSE' || 'TRUE' }}
       - name: Install cmdstan
         uses: ./.github/actions/setup-cmdstan

--- a/R/build-data.R
+++ b/R/build-data.R
@@ -2,8 +2,8 @@
 #'
 #' Some types of models carry around code that builds the input data for the
 #' modeling, instead of relying on a single static file on disk. When necessary,
-#' **this function is called internally by [submit_model()]** to build the data
-#' for running the model, but they can also be called manually by users for
+#' **this function is called internally by [bbr::submit_model()]** to build the
+#' data for running the model, but they can also be called manually by users for
 #' other purposes.
 #'
 #' @details **Currently, only `bbi_stan_model` objects have this implemented.**

--- a/R/copy-model-from.R
+++ b/R/copy-model-from.R
@@ -11,9 +11,10 @@
 #'   a `bbi_nmbayes_model` subclass; in that case, use [bbr::copy_model_from()]
 #'   to copy the model in the standard way.
 #' @param .update_model_file Whether to update the newly created model file. If
-#'   `TRUE`, the model will be adjusted by [copy_model_from()]. In addition, any
-#'   existing estimation records will be deleted, and the two estimation records
-#'   required for nmbayes models will be added along with a comment.
+#'   `TRUE`, the model will be adjusted by [bbr::copy_model_from()]. In
+#'   addition, any existing estimation records will be deleted, and the two
+#'   estimation records required for nmbayes models will be added along with a
+#'   comment.
 #' @return A `bbi_nmbayes_model` object for the new model.
 #' @seealso [bbr_nmbayes] for a high-level description of how NONMEM Bayes
 #'   models are structured in bbr

--- a/R/read-fit-model.R
+++ b/R/read-fit-model.R
@@ -9,7 +9,7 @@
 #'
 #'   * **Stan**: Returns a `cmdstanr` fit object of class `"CmdStanMCMC"`. See the
 #'     `?cmdstanr::CmdStanMCMC` docs for methods and information on this object.
-#'     _Note: currently [model_summary]`.bbi_stan_model()` calls this under the
+#'     _Note: currently [model_summary.bbi_stan_model()] calls this under the
 #'     hood because it contains methods to summarize model outputs and no
 #'     similar methods exist yet in `bbr` for Stan._
 #'

--- a/R/stan-summary-log.R
+++ b/R/stan-summary-log.R
@@ -38,10 +38,9 @@
 #'   draws entirely, set `summary_fns` to an empty list.
 #'
 #' @param summary_fns A list of summary or diagnostic functions passed to
-#'   [posterior::summarize_draws()][draws_summary]. The result will be included
-#'   as a new column, `{variable}_{name}`, where "name" is determined by the
-#'   names of the returned vector or otherwise by the name of the `summary_fns`
-#'   item.
+#'   [posterior::summarize_draws()]. The result will be included as a new
+#'   column, `{variable}_{name}`, where "name" is determined by the names of the
+#'   returned vector or otherwise by the name of the `summary_fns` item.
 #'
 #'   With the default value of `NULL`, the following functions are used:
 #'   [mean()], [stats::median()], [posterior::quantile2()], [posterior::rhat()],

--- a/man/build_data.Rd
+++ b/man/build_data.Rd
@@ -29,8 +29,8 @@ this function solely for the side effect of writing the data to disk.
 \description{
 Some types of models carry around code that builds the input data for the
 modeling, instead of relying on a single static file on disk. When necessary,
-\strong{this function is called internally by \code{\link[=submit_model]{submit_model()}}} to build the data
-for running the model, but they can also be called manually by users for
+\strong{this function is called internally by \code{\link[bbr:submit_model]{bbr::submit_model()}}} to build the
+data for running the model, but they can also be called manually by users for
 other purposes.
 }
 \details{

--- a/man/copy_model_as_nmbayes.Rd
+++ b/man/copy_model_as_nmbayes.Rd
@@ -47,9 +47,10 @@ tags passed to \code{.add_tags} argument. If \code{TRUE} inherit any tags from
 \code{.parent_mod}, with any tags passed to \code{.add_tags} appended.}
 
 \item{.update_model_file}{Whether to update the newly created model file. If
-\code{TRUE}, the model will be adjusted by \code{\link[=copy_model_from]{copy_model_from()}}. In addition, any
-existing estimation records will be deleted, and the two estimation records
-required for nmbayes models will be added along with a comment.}
+\code{TRUE}, the model will be adjusted by \code{\link[bbr:copy_model_from]{bbr::copy_model_from()}}. In
+addition, any existing estimation records will be deleted, and the two
+estimation records required for nmbayes models will be added along with a
+comment.}
 
 \item{.overwrite}{If \code{FALSE}, the default,  function will error if a model
 file already exists at specified \code{.new_model} path. If \code{TRUE} any existing

--- a/man/read_fit_model.Rd
+++ b/man/read_fit_model.Rd
@@ -36,7 +36,7 @@ in the draws constructed for bbi_nmbayes_model objects.}
 \item \strong{NONMEM Bayes}: Returns a \pkg{posterior} draws object.
 \item \strong{Stan}: Returns a \code{cmdstanr} fit object of class \code{"CmdStanMCMC"}. See the
 \code{?cmdstanr::CmdStanMCMC} docs for methods and information on this object.
-\emph{Note: currently \link{model_summary}\code{.bbi_stan_model()} calls this under the
+\emph{Note: currently \code{\link[=model_summary.bbi_stan_model]{model_summary.bbi_stan_model()}} calls this under the
 hood because it contains methods to summarize model outputs and no
 similar methods exist yet in \code{bbr} for Stan.}
 }

--- a/man/stan_summary_log.Rd
+++ b/man/stan_summary_log.Rd
@@ -39,10 +39,9 @@ function returns a named vector). To disable extracting and summarizing the
 draws entirely, set \code{summary_fns} to an empty list.}
 
 \item{summary_fns}{A list of summary or diagnostic functions passed to
-\link[=draws_summary]{posterior::summarize_draws()}. The result will be included
-as a new column, \verb{\{variable\}_\{name\}}, where "name" is determined by the
-names of the returned vector or otherwise by the name of the \code{summary_fns}
-item.
+\code{\link[posterior:draws_summary]{posterior::summarize_draws()}}. The result will be included as a new
+column, \verb{\{variable\}_\{name\}}, where "name" is determined by the names of the
+returned vector or otherwise by the name of the \code{summary_fns} item.
 
 With the default value of \code{NULL}, the following functions are used:
 \code{\link[=mean]{mean()}}, \code{\link[stats:median]{stats::median()}}, \code{\link[posterior:quantile2]{posterior::quantile2()}}, \code{\link[posterior:rhat]{posterior::rhat()}},


### PR DESCRIPTION
 * Fix a failure in the R 4.0 job related to a `scales` update.

 * Bump R versions to match Metworx.

 * Fix new Rd issues flagged by R 4.5.

 * Update the check under the R latest to run with `error_on="note"` to catch issues like the previous one (doing so is possible due to a change in how R 4.5 marks the "too many dependencies" and "package size" messages).
