### PR TITLE
MPN-related upkeep

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,20 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # TODO: When bbr 1.15.0 is in latest MPN, remove
-          #       bbr_revision from all builds except the
-          #       bbr_revision=main one.  Also drop bbr source step
-          #       from release job.
           - os: ubuntu-22.04
             r: 4.0.5
             rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2023-01-25'
-            bbr_revision: 1.15.0
           - os: ubuntu-22.04
             r: 4.3.3
-            bbr_revision: 1.15.0
           - os: ubuntu-22.04
             r: 4.4.2
-            bbr_revision: 1.15.0
           - os: ubuntu-latest
             r: release
             bbr_revision: main
@@ -104,17 +97,9 @@ jobs:
           r-version: release
           use-public-rspm: true
           extra-repositories: 'https://mpn.metworx.com/snapshots/stable/${{ env.MPN_LATEST }}'
-      - name: Configure bbr source
-        shell: bash
-        run: |
-          echo "BBR_PKG=github::metrumresearchgroup/bbr@${{ env.BBR_REV }}" >>"$GITHUB_ENV"
-        env:
-          BBR_REV: 1.15.0
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: |
-            any::pkgpub
-            ${{ env.BBR_PKG }}
+          extra-packages: any::pkgpub
       - name: Install cmdstan
         uses: ./.github/actions/setup-cmdstan
       - uses: metrumresearchgroup/actions/publish-r-release@v1

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ remotes::install_github("metrumresearchgroup/bbr.bayes")
 Note that a few `bbr.bayes` dependencies are not on CRAN but are
 available from other CRAN-like repos:
 
- * [bbr] is available on [MPN].  Use snapshot 2024-03-01 or later to
+ * [bbr] is available on [MPN].  Use snapshot 2026-03-20 or later to
    get the minimum version required by `bbr.bayes`.
 
  * [nmrec] is available on [MPN] as of the 2023-09-19 snapshot.

--- a/pkgr.yml
+++ b/pkgr.yml
@@ -8,7 +8,7 @@ Packages:
 
 Repos:
   - CRAN: https://cran.rstudio.com
-  - MPN: https://mpn.metworx.com/snapshots/stable/2025-05-22 # bbr, cmdstanr, nmrec
+  - MPN: https://mpn.metworx.com/snapshots/stable/2026-03-20 # bbr, cmdstanr, nmrec
 
 Customizations:
   Packages:


### PR DESCRIPTION
The minimum required bbr version is available in the latest MPN snapshot.  Update pkgr.yml, README.md, and the CI to use that snapshot.